### PR TITLE
Post Title substitution - closes #12

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
         "ghcr.io/devcontainers/features/github-cli:1": {},
         "ghcr.io/devcontainers/features/node:1": {
             "version": "22"
-          }
+        }
     },
     "customizations": {
         "vscode": {
@@ -26,7 +26,7 @@
             }
         }
     },
-    "runArgs": ["--env-file",".devcontainer/devcontainer.env"],
+    "runArgs": ["--env-file", ".devcontainer/devcontainer.env"],
 
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     // "forwardPorts": [],

--- a/README.md
+++ b/README.md
@@ -18,29 +18,46 @@ npm install peoplexd-client
 ### Initialize the Client
 
 ```typescript
-import { PeopleXdClient } from 'peoplexd-client';
+import { PeopleXdClient } from 'peoplexd-client'
 
 const client = await PeopleXdClient.new(
-  'https://api.corehr.com/ws/<tenant_id>/corehr/', // include your tenant id
-  'your-client-id', // provided by your PeopleXD admin
-  'your-client-secret' // provided by you PeopleXD admin
-);
+    'https://api.corehr.com/ws/<tenant_id>/corehr/', // include your tenant id
+    'your-client-id', // provided by your PeopleXD admin
+    'your-client-secret' // provided by you PeopleXD admin
+)
+```
+
+## Configuration Options
+
+When initializing the PeopleXdClient, you can provide configuration options:
+
+```typescript
+interface PeopleXdClientOptions {
+    titleCodeSubstitutions?: Record<string, string>
+}
+
+// Example usage:
+const client = await PeopleXdClient.new('https://api.peoplexd.example.com/', 'your-client-id', 'your-client-secret', {
+    titleCodeSubstitutions: {
+        HPAL: 'AL' // Substitute "Hourly Paid Assistant Lecturer" with "Assistant Lecturer"
+    }
+})
 ```
 
 ### Making API Requests
 
 ```typescript
 // Make a direct API request
-const response = await client.request('GET', 'v1/endpoint');
+const response = await client.request('GET', 'v1/endpoint')
 
 // Get staff appointments (processed and cleaned)
-const appointments = await client.cleanAppointments('12345');
+const appointments = await client.cleanAppointments('12345')
 
 // Get department information
-const departmentName = await client.getFullDepartment('IT_DEPT');
+const departmentName = await client.getFullDepartment('IT_DEPT')
 
 // Get position/job title information
-const jobTitle = await client.getFullJobTitle('SOFTWARE_DEV');
+const jobTitle = await client.getFullJobTitle('SOFTWARE_DEV')
 ```
 
 ## API Documentation
@@ -61,14 +78,14 @@ The main client class that provides access to the PeopleXD API.
 
 ```typescript
 interface ProcessedAppointment {
-  appointmentId: string;
-  primaryFlag: boolean;
-  jobTitle: string;
-  fullJobTitle: string;
-  department: string;
-  fullDepartment: string;
-  startDate: string;
-  endDate: string;
+    appointmentId: string
+    primaryFlag: boolean
+    jobTitle: string
+    fullJobTitle: string
+    department: string
+    fullDepartment: string
+    startDate: string
+    endDate: string
 }
 ```
 
@@ -85,19 +102,21 @@ This client handles OAuth authentication automatically. It will:
 ### Setup
 
 1. Clone the repository:
-   ```bash
-   git clone https://github.com/tu-dublin-csu/peoplexd-client.git
-   ```
+
+    ```bash
+    git clone https://github.com/tu-dublin-csu/peoplexd-client.git
+    ```
 
 2. Install dependencies:
-   ```bash 
-   npm install
-   ```
+
+    ```bash
+    npm install
+    ```
 
 3. Build the project:
-   ```bash
-   npm run build
-   ```
+    ```bash
+    npm run build
+    ```
 
 ### Development Container
 
@@ -112,15 +131,21 @@ TEST_STAFF_ID=12345 # used in dummy_proj/main.js
 
 **Note:** the Staging URL will be diferent - see the PeopleXD documentation for details.
 
+A simple script allows you to test against your PeopleXD instance
+
+```
+node ./dummy_proj/main.js
+```
+
 ### Testing
 
 Run tests with:
 
 ```bash
-npm test
+npm run test
 ```
 
-The project uses Jest for testing with TypeScript support and maintains high test coverage.
+The project uses Jest for testing with TypeScript support.
 
 ### Linting and Formatting
 

--- a/dummy_proj/main.js
+++ b/dummy_proj/main.js
@@ -1,13 +1,24 @@
-import { PeopleXdClient } from "../dist/index.js";
+import { PeopleXdClient } from '../dist/index.js'
 
-console.log(process.env.PEOPLEXD_URL);
+console.log(process.env.PEOPLEXD_URL)
 
 try {
-    const client = await PeopleXdClient.new(process.env.PEOPLEXD_URL, process.env.PRODUCTION_PXD_ID, process.env.PRODUCTION_PXD_SECRET);
+    const defaultOptions = {
+        titleCodeSubstitutions: {
+            HPAL: 'AL'
+        }
+    }
+    const client = await PeopleXdClient.new(
+        process.env.PEOPLEXD_URL,
+        process.env.PRODUCTION_PXD_ID,
+        process.env.PRODUCTION_PXD_SECRET,
+        defaultOptions
+    )
 
-    const appointments = await client.cleanAppointments(process.env.TEST_STAFF_ID);
+    console.log(client.getOptions())
+    const appointments = await client.cleanAppointments(process.env.TEST_STAFF_ID)
 
-    console.log(appointments);
+    console.log(appointments)
 } catch (error) {
-    console.error("An error occurred:", error.data);
+    console.error('An error occurred:', error.data)
 }

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -28,10 +28,7 @@ const config: Config = {
     coverageDirectory: 'coverage',
 
     // An array of regexp pattern strings used to skip coverage collection
-    coveragePathIgnorePatterns: [
-      "/node_modules/",
-      "/tests/fixtures/"
-    ],
+    coveragePathIgnorePatterns: ['/node_modules/', '/tests/fixtures/'],
 
     // Indicates which provider should be used to instrument code for coverage
     coverageProvider: 'v8',
@@ -142,7 +139,7 @@ const config: Config = {
     // snapshotSerializers: [],
 
     // The test environment that will be used for testing
-    testEnvironment: 'node',
+    testEnvironment: 'node'
 
     // Options that will be passed to the testEnvironment
     // testEnvironmentOptions: {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "peoplexd-client",
-  "version": "0.0.3-beta",
+  "version": "0.0.4-beta",
   "description": "A TypeScript application to interact with the PeopleXd API",
   "main": "./dist/index.cjs",
   "type": "module",

--- a/src/AppointmentInterfaces.ts
+++ b/src/AppointmentInterfaces.ts
@@ -1,49 +1,49 @@
 export interface Hierarchy {
-    structureCode: string;
-    company: string;
-    managementUnit: string;
-    department: string;
-    costCentre: string;
-    division: string;
-    location: string;
-    workGroup: string;
-    user1: string;
-    user2: string;
-    user3: string;
-    user4: string;
-    user5: string;
+    structureCode: string
+    company: string
+    managementUnit: string
+    department: string
+    costCentre: string
+    division: string
+    location: string
+    workGroup: string
+    user1: string
+    user2: string
+    user3: string
+    user4: string
+    user5: string
 }
 
 export interface RawAppointment {
-    appointmentId: string;
-    appointmentStatus: string;
-    employeeStatus: string;
-    jobDescription: string;
-    primaryFlag: string;
-    category: string;
-    subCategory: string;
-    startDate: string;
-    endDate: string;
-    lastAmendedDate: string;
-    targetEndDate: string;
-    FTE: string;
-    contractId: string;
-    jobTitle: string;
-    jobCategory: string;
-    project: string;
-    postNumber: string;
-    reasonCode: string;
-    action: string;
-    hierarchy: Hierarchy;
+    appointmentId: string
+    appointmentStatus: string
+    employeeStatus: string
+    jobDescription: string
+    primaryFlag: string
+    category: string
+    subCategory: string
+    startDate: string
+    endDate: string
+    lastAmendedDate: string
+    targetEndDate: string
+    FTE: string
+    contractId: string
+    jobTitle: string
+    jobCategory: string
+    project: string
+    postNumber: string
+    reasonCode: string
+    action: string
+    hierarchy: Hierarchy
 }
 
 export interface ProcessedAppointment {
-    appointmentId: string;
-    primaryFlag: boolean;
-    jobTitle: string;
-    fullJobTitle: string;
-    department: string;
-    fullDepartment: string;
-    startDate: string;
-    endDate: string;
+    appointmentId: string
+    primaryFlag: boolean
+    jobTitle: string
+    fullJobTitle: string
+    department: string
+    fullDepartment: string
+    startDate: string
+    endDate: string
 }

--- a/src/AppointmentProcessorService.ts
+++ b/src/AppointmentProcessorService.ts
@@ -1,5 +1,5 @@
-import { RawAppointment, ProcessedAppointment } from "./AppointmentInterfaces";
-export { ProcessedAppointment }; 
+import { RawAppointment, ProcessedAppointment } from './AppointmentInterfaces'
+export { ProcessedAppointment }
 
 export class AppointmentProcessorService {
     /**
@@ -10,65 +10,75 @@ export class AppointmentProcessorService {
      */
     public static processAppointments(rawAppointments: RawAppointment[]): ProcessedAppointment[] {
         if (!rawAppointments || rawAppointments.length === 0) {
-            return [];
+            return []
         }
 
         // Sort appointments by startDate
-        rawAppointments.sort((a, b) => this.parseDate(a.startDate).getTime() - this.parseDate(b.startDate).getTime());
+        rawAppointments.sort((a, b) => this.parseDate(a.startDate).getTime() - this.parseDate(b.startDate).getTime())
 
-        const mergedAppointments: ProcessedAppointment[] = [];
-        const currentAppointment = this.createProcessedAppointment(rawAppointments[0]);
+        const mergedAppointments: ProcessedAppointment[] = []
+        const currentAppointment = this.createProcessedAppointment(rawAppointments[0])
 
-        console.log('Processing appointments...');
+        console.log('Processing appointments...')
 
-        this.mergeAppointments(rawAppointments, mergedAppointments, currentAppointment);
+        this.mergeAppointments(rawAppointments, mergedAppointments, currentAppointment)
 
-        return mergedAppointments;
+        return mergedAppointments
     }
 
-    private static mergeAppointments(rawAppointments: RawAppointment[], mergedAppointments: ProcessedAppointment[], currentAppointment: ProcessedAppointment): void {
+    private static mergeAppointments(
+        rawAppointments: RawAppointment[],
+        mergedAppointments: ProcessedAppointment[],
+        currentAppointment: ProcessedAppointment
+    ): void {
         for (let i = 1; i < rawAppointments.length; i++) {
-            const nextAppointment = rawAppointments[i];
+            const nextAppointment = rawAppointments[i]
 
-            console.log(`Processing appointment ${i + 1} of ${rawAppointments.length}`);
+            console.log(`Processing appointment ${i + 1} of ${rawAppointments.length}`)
 
             if (this.shouldSkipAppointment(currentAppointment, nextAppointment)) {
-                continue;
+                continue
             }
 
-            const daysDifference = this.calculateDaysDifference(currentAppointment.endDate, nextAppointment.startDate);
+            const daysDifference = this.calculateDaysDifference(currentAppointment.endDate, nextAppointment.startDate)
 
-            console.log(`Days difference: ${daysDifference}`);
+            console.log(`Days difference: ${daysDifference}`)
 
             if (this.shouldMergeAppointments(currentAppointment, nextAppointment, daysDifference)) {
-                console.log('Merging appointments...');
-                currentAppointment = this.mergeTwoAppointments(currentAppointment, nextAppointment);
+                console.log('Merging appointments...')
+                currentAppointment = this.mergeTwoAppointments(currentAppointment, nextAppointment)
             } else {
-                mergedAppointments.push(currentAppointment);
-                currentAppointment = this.createProcessedAppointment(nextAppointment);
+                mergedAppointments.push(currentAppointment)
+                currentAppointment = this.createProcessedAppointment(nextAppointment)
             }
         }
 
-        mergedAppointments.push(currentAppointment);
+        mergedAppointments.push(currentAppointment)
     }
 
     private static parseDate(dateString: string): Date {
-        const year = parseInt(dateString.substring(0, 4), 10);
-        const month = parseInt(dateString.substring(4, 6), 10) - 1; // Months are 0-based in JavaScript
-        const day = parseInt(dateString.substring(6, 8), 10);
-        return new Date(year, month, day);
+        const year = parseInt(dateString.substring(0, 4), 10)
+        const month = parseInt(dateString.substring(4, 6), 10) - 1 // Months are 0-based in JavaScript
+        const day = parseInt(dateString.substring(6, 8), 10)
+        return new Date(year, month, day)
     }
 
     private static calculateDaysDifference(endDate: string, startDate: string): number {
-        const currentEndDate = this.parseDate(endDate);
-        const nextStartDate = this.parseDate(startDate);
-        return (nextStartDate.getTime() - currentEndDate.getTime()) / (1000 * 3600 * 24);
+        const currentEndDate = this.parseDate(endDate)
+        const nextStartDate = this.parseDate(startDate)
+        return (nextStartDate.getTime() - currentEndDate.getTime()) / (1000 * 3600 * 24)
     }
 
-    private static shouldMergeAppointments(currentAppointment: ProcessedAppointment, nextAppointment: RawAppointment, daysDifference: number): boolean {
-        return currentAppointment.jobTitle === nextAppointment.jobTitle &&
+    private static shouldMergeAppointments(
+        currentAppointment: ProcessedAppointment,
+        nextAppointment: RawAppointment,
+        daysDifference: number
+    ): boolean {
+        return (
+            currentAppointment.jobTitle === nextAppointment.jobTitle &&
             currentAppointment.department === nextAppointment.hierarchy.department &&
-            (daysDifference <= 90 || daysDifference < 0); // Merge if within 90 days or overlapping
+            (daysDifference <= 90 || daysDifference < 0)
+        ) // Merge if within 90 days or overlapping
     }
 
     private static createProcessedAppointment(rawAppointment: RawAppointment): ProcessedAppointment {
@@ -81,26 +91,31 @@ export class AppointmentProcessorService {
             fullDepartment: rawAppointment.hierarchy.department,
             startDate: rawAppointment.startDate,
             endDate: rawAppointment.endDate
-        };
+        }
     }
 
     private static getLaterDate(date1: string, date2: string): string {
-        const parsedDate1 = this.parseDate(date1);
-        const parsedDate2 = this.parseDate(date2);
-        return parsedDate1 > parsedDate2 ? date1 : date2;
+        const parsedDate1 = this.parseDate(date1)
+        const parsedDate2 = this.parseDate(date2)
+        return parsedDate1 > parsedDate2 ? date1 : date2
     }
 
-    private static shouldSkipAppointment(currentAppointment: ProcessedAppointment, nextAppointment: RawAppointment): boolean {
+    private static shouldSkipAppointment(
+        currentAppointment: ProcessedAppointment,
+        nextAppointment: RawAppointment
+    ): boolean {
         if (!currentAppointment.endDate || !nextAppointment.startDate) {
-            console.warn('Skipping appointment due to missing startDate or endDate');
-            return true;
+            console.warn('Skipping appointment due to missing startDate or endDate')
+            return true
         }
-        return false;
+        return false
     }
 
-    private static mergeTwoAppointments(currentAppointment: ProcessedAppointment, nextAppointment: RawAppointment): ProcessedAppointment {
-        currentAppointment.endDate = this.getLaterDate(currentAppointment.endDate, nextAppointment.endDate);
-        return currentAppointment;
+    private static mergeTwoAppointments(
+        currentAppointment: ProcessedAppointment,
+        nextAppointment: RawAppointment
+    ): ProcessedAppointment {
+        currentAppointment.endDate = this.getLaterDate(currentAppointment.endDate, nextAppointment.endDate)
+        return currentAppointment
     }
 }
-

--- a/src/AppointmentService.ts
+++ b/src/AppointmentService.ts
@@ -1,28 +1,28 @@
-import { RawAppointment, ProcessedAppointment } from "./AppointmentInterfaces";
-import { AppointmentProcessorService } from './AppointmentProcessorService';
-import { PeopleXdClient } from './PeopleXdClient';
+import { RawAppointment, ProcessedAppointment } from './AppointmentInterfaces'
+import { AppointmentProcessorService } from './AppointmentProcessorService'
+import { PeopleXdClient } from './PeopleXdClient'
 
 export class AppointmentService {
-    private client: PeopleXdClient;
+    private client: PeopleXdClient
 
     constructor(client: PeopleXdClient) {
-        this.client = client;
+        this.client = client
     }
 
     public async getAppointments(staffNumber: string): Promise<RawAppointment[]> {
-        const response = await this.client.request('GET', `v1/person/appointment/${staffNumber}`);
-        return response.data.items as RawAppointment[];
+        const response = await this.client.request('GET', `v1/person/appointment/${staffNumber}`)
+        return response.data.items as RawAppointment[]
     }
 
     public async cleanAppointments(staffNumber: string): Promise<ProcessedAppointment[]> {
-        const rawAppointments = await this.getAppointments(staffNumber);
-        const processedAppointments: ProcessedAppointment[] = [];
+        const rawAppointments = await this.getAppointments(staffNumber)
+        const processedAppointments: ProcessedAppointment[] = []
 
-        const cleanedAppointments = AppointmentProcessorService.processAppointments(rawAppointments);
+        const cleanedAppointments = AppointmentProcessorService.processAppointments(rawAppointments)
 
         for (const cleanedAppointment of cleanedAppointments) {
-            const fullDepartment = await this.client.getFullDepartment(cleanedAppointment.department);
-            const fullJobTitle = await this.client.getFullJobTitle(cleanedAppointment.jobTitle);
+            const fullDepartment = await this.client.getFullDepartment(cleanedAppointment.department)
+            const fullJobTitle = await this.client.getFullJobTitle(cleanedAppointment.jobTitle)
 
             processedAppointments.push({
                 appointmentId: cleanedAppointment.appointmentId,
@@ -33,9 +33,9 @@ export class AppointmentService {
                 fullDepartment: fullDepartment,
                 startDate: cleanedAppointment.startDate,
                 endDate: cleanedAppointment.endDate
-            });
+            })
         }
 
-        return processedAppointments;
+        return processedAppointments
     }
 }

--- a/src/DepartmentService.ts
+++ b/src/DepartmentService.ts
@@ -1,20 +1,20 @@
-import { AxiosResponse } from 'axios';
-import { PeopleXdClient } from './PeopleXdClient';
-import { decodeHtml } from './Utilities';
+import { AxiosResponse } from 'axios'
+import { PeopleXdClient } from './PeopleXdClient'
+import { decodeHtml } from './Utilities'
 
 export class DepartmentService {
-    private client: PeopleXdClient;
+    private client: PeopleXdClient
 
     constructor(client: PeopleXdClient) {
-        this.client = client;
+        this.client = client
     }
 
     public async getDepartment(deptCode: string): Promise<AxiosResponse> {
-        return await this.client.request('GET', `v1/reference/type/DEPT/${deptCode}`);
+        return await this.client.request('GET', `v1/reference/type/DEPT/${deptCode}`)
     }
 
     public async getFullDepartment(deptCode: string): Promise<string> {
-        const response = await this.getDepartment(deptCode);
-        return decodeHtml(response.data.items[0].description);
+        const response = await this.getDepartment(deptCode)
+        return decodeHtml(response.data.items[0].description)
     }
 }

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -1,20 +1,20 @@
-import axios, { AxiosResponse } from 'axios';
+import axios, { AxiosResponse } from 'axios'
 
 export class HttpClient {
-    private url: string;
-    private token: string;
+    private url: string
+    private token: string
 
     constructor(url: string, token: string) {
-        this.url = url;
-        this.token = token;
+        this.url = url
+        this.token = token
     }
 
     public async request(method: string, endpoint: string, body: unknown = null): Promise<AxiosResponse> {
-        const uri = `${this.url}${endpoint}`;
+        const uri = `${this.url}${endpoint}`
         const headers = {
-            'Authorization': `Bearer ${this.token}`,
+            Authorization: `Bearer ${this.token}`,
             'Content-Type': 'application/json'
-        };
+        }
 
         try {
             const response = await axios({
@@ -22,14 +22,14 @@ export class HttpClient {
                 url: uri,
                 headers,
                 data: body
-            });
-            console.debug(`${method.toUpperCase()} ${uri} response: ${JSON.stringify(response.data, null, 2)}`);
-            return response;
+            })
+            console.debug(`${method.toUpperCase()} ${uri} response: ${JSON.stringify(response.data, null, 2)}`)
+            return response
         } catch (error: unknown) {
             console.error(
                 `Error during ${method.toUpperCase()} request to ${uri}: ${error instanceof Error ? error.message : error}`
-            );
-            throw error;
+            )
+            throw error
         }
     }
 }

--- a/src/PeopleXdClient.ts
+++ b/src/PeopleXdClient.ts
@@ -1,10 +1,10 @@
-import { AxiosResponse } from 'axios';
-import { TokenManagerService } from './TokenManagerService';
-import { ProcessedAppointment } from './AppointmentInterfaces';
-import { HttpClient } from './HttpClient';
-import { AppointmentService } from './AppointmentService';
-import { DepartmentService } from './DepartmentService';
-import { PositionService } from './PositionService';
+import { AxiosResponse } from 'axios'
+import { TokenManagerService } from './TokenManagerService'
+import { ProcessedAppointment } from './AppointmentInterfaces'
+import { HttpClient } from './HttpClient'
+import { AppointmentService } from './AppointmentService'
+import { DepartmentService } from './DepartmentService'
+import { PositionService } from './PositionService'
 
 export enum HttpRequestMethod {
     GET = 'get',
@@ -14,42 +14,73 @@ export enum HttpRequestMethod {
 }
 
 /**
+ * Configuration options for PeopleXdClient
+ */
+export interface PeopleXdClientOptions {
+    /**
+     * Map of position codes to their substitutions
+     * Example: { 'HPAL': 'AL' } would replace "Hourly Paid Assistant Lecturer" with "Assistant Lecturer"
+     */
+    titleCodeSubstitutions?: Record<string, string>
+}
+
+/**
  * PeopleXdClient class to interact with the PeopleXD API.
  */
 export class PeopleXdClient {
-    private httpClient: HttpClient;
-    private appointmentService: AppointmentService;
-    private departmentService: DepartmentService;
-    private positionService: PositionService;
-    static tokenManager: TokenManagerService;
+    private httpClient: HttpClient
+    private appointmentService: AppointmentService
+    private departmentService: DepartmentService
+    private positionService: PositionService
+    private options: PeopleXdClientOptions
+    static tokenManager: TokenManagerService
 
-    private constructor(httpClient: HttpClient) {
-        this.httpClient = httpClient;
-        this.appointmentService = new AppointmentService(this);
-        this.departmentService = new DepartmentService(this);
-        this.positionService = new PositionService(this);
+    private constructor(httpClient: HttpClient, options: PeopleXdClientOptions = {}) {
+        this.httpClient = httpClient
+        this.options = options
+        this.appointmentService = new AppointmentService(this)
+        this.departmentService = new DepartmentService(this)
+        this.positionService = new PositionService(this)
     }
 
-    static async new(url: string, clientId: string, clientSecret: string): Promise<PeopleXdClient> {
-        this.tokenManager = await TokenManagerService.new(url, clientId, clientSecret);
-        const token = await this.tokenManager.useOrFetchToken();
-        const httpClient = new HttpClient(url, token);
-        return new PeopleXdClient(httpClient);
+    static async new(
+        url: string,
+        clientId: string,
+        clientSecret: string,
+        options: PeopleXdClientOptions = {}
+    ): Promise<PeopleXdClient> {
+        this.tokenManager = await TokenManagerService.new(url, clientId, clientSecret)
+        const token = await this.tokenManager.useOrFetchToken()
+        const httpClient = new HttpClient(url, token)
+        return new PeopleXdClient(httpClient, options)
     }
 
-    public async request(method: string, endpoint: string, body: Record<string, unknown> | null = null): Promise<AxiosResponse> {
-        return await this.httpClient.request(method, endpoint, body);
+    public async request(
+        method: string,
+        endpoint: string,
+        body: Record<string, unknown> | null = null
+    ): Promise<AxiosResponse> {
+        return await this.httpClient.request(method, endpoint, body)
     }
 
     public async getFullDepartment(deptCode: string): Promise<string> {
-        return await this.departmentService.getFullDepartment(deptCode);
+        return await this.departmentService.getFullDepartment(deptCode)
     }
 
     public async getFullJobTitle(positionCode: string): Promise<string> {
-        return await this.positionService.getFullJobTitle(positionCode);
+        // Apply code substitution if one exists
+        const substitutedCode = this.options.titleCodeSubstitutions?.[positionCode] || positionCode
+        return await this.positionService.getFullJobTitle(substitutedCode)
     }
 
     public async cleanAppointments(staffNumber: string): Promise<ProcessedAppointment[]> {
-        return await this.appointmentService.cleanAppointments(staffNumber);
+        return await this.appointmentService.cleanAppointments(staffNumber)
+    }
+
+    /**
+     * Get the client configuration options
+     */
+    public getOptions(): PeopleXdClientOptions {
+        return this.options
     }
 }

--- a/src/PositionService.ts
+++ b/src/PositionService.ts
@@ -1,20 +1,20 @@
-import { AxiosResponse } from 'axios';
-import { PeopleXdClient } from './PeopleXdClient';
-import { decodeHtml } from './Utilities';
+import { AxiosResponse } from 'axios'
+import { PeopleXdClient } from './PeopleXdClient'
+import { decodeHtml } from './Utilities'
 
 export class PositionService {
-    private client: PeopleXdClient;
+    private client: PeopleXdClient
 
     constructor(client: PeopleXdClient) {
-        this.client = client;
+        this.client = client
     }
 
     public async getPositionTitle(positionCode: string): Promise<AxiosResponse> {
-        return await this.client.request('GET', `v1/reference/type/POSTTL/${positionCode}`);
+        return await this.client.request('GET', `v1/reference/type/POSTTL/${positionCode}`)
     }
 
     public async getFullJobTitle(positionCode: string): Promise<string> {
-        const response = await this.getPositionTitle(positionCode);
-        return decodeHtml(response.data.items[0].description);
+        const response = await this.getPositionTitle(positionCode)
+        return decodeHtml(response.data.items[0].description)
     }
 }

--- a/src/Utilities.ts
+++ b/src/Utilities.ts
@@ -1,5 +1,5 @@
-import { decode } from 'html-entities';
+import { decode } from 'html-entities'
 
 export function decodeHtml(text: string): string {
-    return decode(text);
+    return decode(text)
 }

--- a/tests/AppointmentProcessorService.test.ts
+++ b/tests/AppointmentProcessorService.test.ts
@@ -1,59 +1,60 @@
-import { AppointmentProcessorService } from '../src/AppointmentProcessorService';
-import { 
-  createRawAppointment, 
-  createMergeableAppointmentPair
-} from './fixtures/AppointmentFixturesFactory';
+import { AppointmentProcessorService } from '../src/AppointmentProcessorService'
+import { createRawAppointment, createMergeableAppointmentPair } from './fixtures/AppointmentFixturesFactory'
 
 describe('AppointmentProcessorService', () => {
-  describe('processAppointments', () => {
-    it('should return an empty array when input is empty', () => {
-      expect(AppointmentProcessorService.processAppointments([])).toEqual([]);
-      expect(AppointmentProcessorService.processAppointments(undefined as unknown as Array<ReturnType<typeof createRawAppointment>>)).toEqual([]);
-    });
+    describe('processAppointments', () => {
+        it('should return an empty array when input is empty', () => {
+            expect(AppointmentProcessorService.processAppointments([])).toEqual([])
+            expect(
+                AppointmentProcessorService.processAppointments(
+                    undefined as unknown as Array<ReturnType<typeof createRawAppointment>>
+                )
+            ).toEqual([])
+        })
 
-    it('should process a single appointment correctly', () => {
-      const rawAppointments = [createRawAppointment()];
-      const result = AppointmentProcessorService.processAppointments(rawAppointments);
-      
-      expect(result.length).toBe(1);
-      expect(result[0].appointmentId).toEqual(rawAppointments[0].appointmentId);
-      expect(result[0].primaryFlag).toBe(rawAppointments[0].primaryFlag === 'Y');
-      expect(result[0].jobTitle).toEqual(rawAppointments[0].jobTitle);
-      expect(result[0].department).toEqual(rawAppointments[0].hierarchy.department);
-    });
+        it('should process a single appointment correctly', () => {
+            const rawAppointments = [createRawAppointment()]
+            const result = AppointmentProcessorService.processAppointments(rawAppointments)
 
-    it('should merge contiguous appointments with same job title and department', () => {
-      const rawAppointments = createMergeableAppointmentPair(true, 1);
-      const result = AppointmentProcessorService.processAppointments(rawAppointments);
-      
-      // Should merge into a single appointment
-      expect(result.length).toBe(1);
-      expect(result[0].startDate).toBe(rawAppointments[0].startDate);
-      expect(result[0].endDate).toBe(rawAppointments[1].endDate);
-    });
+            expect(result.length).toBe(1)
+            expect(result[0].appointmentId).toEqual(rawAppointments[0].appointmentId)
+            expect(result[0].primaryFlag).toBe(rawAppointments[0].primaryFlag === 'Y')
+            expect(result[0].jobTitle).toEqual(rawAppointments[0].jobTitle)
+            expect(result[0].department).toEqual(rawAppointments[0].hierarchy.department)
+        })
 
-    it('should not merge appointments with different job titles or departments', () => {
-      const rawAppointments = createMergeableAppointmentPair(false, 1);
-      const result = AppointmentProcessorService.processAppointments(rawAppointments);
-      
-      // Should not merge
-      expect(result.length).toBe(2);
-    });
+        it('should merge contiguous appointments with same job title and department', () => {
+            const rawAppointments = createMergeableAppointmentPair(true, 1)
+            const result = AppointmentProcessorService.processAppointments(rawAppointments)
 
-    it('should merge appointments within 90 days of each other', () => {
-      const rawAppointments = createMergeableAppointmentPair(true, 90);
-      const result = AppointmentProcessorService.processAppointments(rawAppointments);
-      
-      // Should merge into a single appointment
-      expect(result.length).toBe(1);
-    });
+            // Should merge into a single appointment
+            expect(result.length).toBe(1)
+            expect(result[0].startDate).toBe(rawAppointments[0].startDate)
+            expect(result[0].endDate).toBe(rawAppointments[1].endDate)
+        })
 
-    it('should not merge appointments more than 90 days apart', () => {
-      const rawAppointments = createMergeableAppointmentPair(true, 91);
-      const result = AppointmentProcessorService.processAppointments(rawAppointments);
-      
-      // Should not merge
-      expect(result.length).toBe(2);
-    });
-  });
-});
+        it('should not merge appointments with different job titles or departments', () => {
+            const rawAppointments = createMergeableAppointmentPair(false, 1)
+            const result = AppointmentProcessorService.processAppointments(rawAppointments)
+
+            // Should not merge
+            expect(result.length).toBe(2)
+        })
+
+        it('should merge appointments within 90 days of each other', () => {
+            const rawAppointments = createMergeableAppointmentPair(true, 90)
+            const result = AppointmentProcessorService.processAppointments(rawAppointments)
+
+            // Should merge into a single appointment
+            expect(result.length).toBe(1)
+        })
+
+        it('should not merge appointments more than 90 days apart', () => {
+            const rawAppointments = createMergeableAppointmentPair(true, 91)
+            const result = AppointmentProcessorService.processAppointments(rawAppointments)
+
+            // Should not merge
+            expect(result.length).toBe(2)
+        })
+    })
+})

--- a/tests/AppointmentService.test.ts
+++ b/tests/AppointmentService.test.ts
@@ -1,223 +1,227 @@
-import { AxiosResponse, AxiosHeaders } from 'axios';
-import { AppointmentService } from '../src/AppointmentService';
-import { PeopleXdClient } from '../src/PeopleXdClient';
-import { AppointmentProcessorService } from '../src/AppointmentProcessorService';
-import { RawAppointment, ProcessedAppointment } from '../src/AppointmentInterfaces';
-import { createRawAppointment, createProcessedAppointment, createHierarchy } from './fixtures/AppointmentFixturesFactory';
+import { AxiosResponse, AxiosHeaders } from 'axios'
+import { AppointmentService } from '../src/AppointmentService'
+import { PeopleXdClient } from '../src/PeopleXdClient'
+import { AppointmentProcessorService } from '../src/AppointmentProcessorService'
+import { RawAppointment, ProcessedAppointment } from '../src/AppointmentInterfaces'
+import {
+    createRawAppointment,
+    createProcessedAppointment,
+    createHierarchy
+} from './fixtures/AppointmentFixturesFactory'
 
 // Mock dependencies
-jest.mock('../src/PeopleXdClient');
-jest.mock('../src/AppointmentProcessorService');
+jest.mock('../src/PeopleXdClient')
+jest.mock('../src/AppointmentProcessorService')
 
 describe('AppointmentService', () => {
-  let client: jest.Mocked<PeopleXdClient>;
-  let appointmentService: AppointmentService;
-  const staffNumber = '12345';
+    let client: jest.Mocked<PeopleXdClient>
+    let appointmentService: AppointmentService
+    const staffNumber = '12345'
 
-  beforeEach(() => {
-    // Create a mock PeopleXdClient
-    client = {
-      request: jest.fn(),
-      getFullDepartment: jest.fn(),
-      getFullJobTitle: jest.fn(),
-    } as unknown as jest.Mocked<PeopleXdClient>;
+    beforeEach(() => {
+        // Create a mock PeopleXdClient
+        client = {
+            request: jest.fn(),
+            getFullDepartment: jest.fn(),
+            getFullJobTitle: jest.fn()
+        } as unknown as jest.Mocked<PeopleXdClient>
 
-    // Create an instance of AppointmentService with the mock client
-    appointmentService = new AppointmentService(client);
-  });
+        // Create an instance of AppointmentService with the mock client
+        appointmentService = new AppointmentService(client)
+    })
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
+    afterEach(() => {
+        jest.clearAllMocks()
+    })
 
-  describe('getAppointments', () => {
-    it('should fetch appointments for a staff number', async () => {
-      // Sample raw appointments to be returned by the API
-      const rawAppointments: RawAppointment[] = [
-        createRawAppointment({ appointmentId: 'APP1' }),
-        createRawAppointment({ appointmentId: 'APP2' })
-      ];
+    describe('getAppointments', () => {
+        it('should fetch appointments for a staff number', async () => {
+            // Sample raw appointments to be returned by the API
+            const rawAppointments: RawAppointment[] = [
+                createRawAppointment({ appointmentId: 'APP1' }),
+                createRawAppointment({ appointmentId: 'APP2' })
+            ]
 
-      // Mock response from the client request
-      const mockResponse: AxiosResponse = {
-        data: { items: rawAppointments },
-        status: 200,
-        statusText: 'OK',
-        headers: {},
-        config: { headers: new AxiosHeaders() }
-      };
+            // Mock response from the client request
+            const mockResponse: AxiosResponse = {
+                data: { items: rawAppointments },
+                status: 200,
+                statusText: 'OK',
+                headers: {},
+                config: { headers: new AxiosHeaders() }
+            }
 
-      // Setup the mock
-      client.request.mockResolvedValue(mockResponse);
+            // Setup the mock
+            client.request.mockResolvedValue(mockResponse)
 
-      // Call the method
-      const result = await appointmentService.getAppointments(staffNumber);
+            // Call the method
+            const result = await appointmentService.getAppointments(staffNumber)
 
-      // Verify the client request was called with the correct parameters
-      expect(client.request).toHaveBeenCalledWith('GET', `v1/person/appointment/${staffNumber}`);
-      
-      // Verify the result
-      expect(result).toEqual(rawAppointments);
-      expect(result.length).toBe(2);
-      expect(result[0].appointmentId).toBe('APP1');
-      expect(result[1].appointmentId).toBe('APP2');
-    });
+            // Verify the client request was called with the correct parameters
+            expect(client.request).toHaveBeenCalledWith('GET', `v1/person/appointment/${staffNumber}`)
 
-    it('should handle empty response', async () => {
-      // Mock response with no appointments
-      const mockResponse: AxiosResponse = {
-        data: { items: [] },
-        status: 200,
-        statusText: 'OK',
-        headers: {},
-        config: { headers: new AxiosHeaders() }
-      };
-
-      // Setup the mock
-      client.request.mockResolvedValue(mockResponse);
-
-      // Call the method
-      const result = await appointmentService.getAppointments(staffNumber);
-
-      // Verify the result
-      expect(result).toEqual([]);
-      expect(result.length).toBe(0);
-    });
-
-    it('should handle errors from the API', async () => {
-      // Mock an error response
-      const errorMessage = 'API Error';
-      client.request.mockRejectedValue(new Error(errorMessage));
-
-      // Expect the method to throw the error
-      await expect(appointmentService.getAppointments(staffNumber)).rejects.toThrow(errorMessage);
-    });
-  });
-
-  describe('cleanAppointments', () => {
-    it('should process and enrich appointments with full department and job title', async () => {
-      // Sample raw appointments
-      const rawAppointments: RawAppointment[] = [
-        createRawAppointment({
-          appointmentId: 'APP1',
-          jobTitle: 'DEV',
-          hierarchy: createHierarchy({ department: 'IT' })
+            // Verify the result
+            expect(result).toEqual(rawAppointments)
+            expect(result.length).toBe(2)
+            expect(result[0].appointmentId).toBe('APP1')
+            expect(result[1].appointmentId).toBe('APP2')
         })
-      ];
 
-      // Sample processed appointments (after AppointmentProcessorService)
-      const processedAppointments: ProcessedAppointment[] = [
-        createProcessedAppointment({
-          appointmentId: 'APP1',
-          jobTitle: 'DEV', 
-          department: 'IT'
+        it('should handle empty response', async () => {
+            // Mock response with no appointments
+            const mockResponse: AxiosResponse = {
+                data: { items: [] },
+                status: 200,
+                statusText: 'OK',
+                headers: {},
+                config: { headers: new AxiosHeaders() }
+            }
+
+            // Setup the mock
+            client.request.mockResolvedValue(mockResponse)
+
+            // Call the method
+            const result = await appointmentService.getAppointments(staffNumber)
+
+            // Verify the result
+            expect(result).toEqual([])
+            expect(result.length).toBe(0)
         })
-      ];
 
-      // Expected final result
-      const expectedResult: ProcessedAppointment[] = [
-        {
-          ...processedAppointments[0],
-          fullJobTitle: 'Software Developer',
-          fullDepartment: 'Information Technology Department'
-        }
-      ];
+        it('should handle errors from the API', async () => {
+            // Mock an error response
+            const errorMessage = 'API Error'
+            client.request.mockRejectedValue(new Error(errorMessage))
 
-      // Setup mocks
-      jest.spyOn(appointmentService, 'getAppointments').mockResolvedValue(rawAppointments);
-      (AppointmentProcessorService.processAppointments as jest.Mock).mockReturnValue(processedAppointments);
-      client.getFullDepartment.mockResolvedValue('Information Technology Department');
-      client.getFullJobTitle.mockResolvedValue('Software Developer');
-
-      // Call the method
-      const result = await appointmentService.cleanAppointments(staffNumber);
-
-      // Verify method calls
-      expect(appointmentService.getAppointments).toHaveBeenCalledWith(staffNumber);
-      expect(AppointmentProcessorService.processAppointments).toHaveBeenCalledWith(rawAppointments);
-      expect(client.getFullDepartment).toHaveBeenCalledWith('IT');
-      expect(client.getFullJobTitle).toHaveBeenCalledWith('DEV');
-
-      // Verify result
-      expect(result).toEqual(expectedResult);
-      expect(result[0].fullJobTitle).toBe('Software Developer');
-      expect(result[0].fullDepartment).toBe('Information Technology Department');
-    });
-
-    it('should handle multiple appointments correctly', async () => {
-      // Sample raw appointments
-      const rawAppointments: RawAppointment[] = [
-        createRawAppointment({
-          appointmentId: 'APP1',
-          jobTitle: 'DEV', 
-          hierarchy: createHierarchy({ department: 'IT' })
-        }),
-        createRawAppointment({
-          appointmentId: 'APP2',
-          jobTitle: 'MGR', 
-          hierarchy: createHierarchy({ department: 'HR' })
+            // Expect the method to throw the error
+            await expect(appointmentService.getAppointments(staffNumber)).rejects.toThrow(errorMessage)
         })
-      ];
+    })
 
-      // Sample processed appointments (after merging/processing)
-      const processedAppointments: ProcessedAppointment[] = [
-        createProcessedAppointment({
-          appointmentId: 'APP1',
-          jobTitle: 'DEV', 
-          department: 'IT'
-        }),
-        createProcessedAppointment({
-          appointmentId: 'APP2',
-          jobTitle: 'MGR', 
-          department: 'HR'
+    describe('cleanAppointments', () => {
+        it('should process and enrich appointments with full department and job title', async () => {
+            // Sample raw appointments
+            const rawAppointments: RawAppointment[] = [
+                createRawAppointment({
+                    appointmentId: 'APP1',
+                    jobTitle: 'DEV',
+                    hierarchy: createHierarchy({ department: 'IT' })
+                })
+            ]
+
+            // Sample processed appointments (after AppointmentProcessorService)
+            const processedAppointments: ProcessedAppointment[] = [
+                createProcessedAppointment({
+                    appointmentId: 'APP1',
+                    jobTitle: 'DEV',
+                    department: 'IT'
+                })
+            ]
+
+            // Expected final result
+            const expectedResult: ProcessedAppointment[] = [
+                {
+                    ...processedAppointments[0],
+                    fullJobTitle: 'Software Developer',
+                    fullDepartment: 'Information Technology Department'
+                }
+            ]
+
+            // Setup mocks
+            jest.spyOn(appointmentService, 'getAppointments').mockResolvedValue(rawAppointments)
+            ;(AppointmentProcessorService.processAppointments as jest.Mock).mockReturnValue(processedAppointments)
+            client.getFullDepartment.mockResolvedValue('Information Technology Department')
+            client.getFullJobTitle.mockResolvedValue('Software Developer')
+
+            // Call the method
+            const result = await appointmentService.cleanAppointments(staffNumber)
+
+            // Verify method calls
+            expect(appointmentService.getAppointments).toHaveBeenCalledWith(staffNumber)
+            expect(AppointmentProcessorService.processAppointments).toHaveBeenCalledWith(rawAppointments)
+            expect(client.getFullDepartment).toHaveBeenCalledWith('IT')
+            expect(client.getFullJobTitle).toHaveBeenCalledWith('DEV')
+
+            // Verify result
+            expect(result).toEqual(expectedResult)
+            expect(result[0].fullJobTitle).toBe('Software Developer')
+            expect(result[0].fullDepartment).toBe('Information Technology Department')
         })
-      ];
 
-      // Setup mocks
-      jest.spyOn(appointmentService, 'getAppointments').mockResolvedValue(rawAppointments);
-      (AppointmentProcessorService.processAppointments as jest.Mock).mockReturnValue(processedAppointments);
-      
-      // Mock different responses for different departments/job titles
-      client.getFullDepartment.mockImplementation((dept) => {
-        if (dept === 'IT') return Promise.resolve('Information Technology Department');
-        if (dept === 'HR') return Promise.resolve('Human Resources Department');
-        return Promise.resolve(dept);
-      });
-      
-      client.getFullJobTitle.mockImplementation((title) => {
-        if (title === 'DEV') return Promise.resolve('Software Developer');
-        if (title === 'MGR') return Promise.resolve('Manager');
-        return Promise.resolve(title);
-      });
+        it('should handle multiple appointments correctly', async () => {
+            // Sample raw appointments
+            const rawAppointments: RawAppointment[] = [
+                createRawAppointment({
+                    appointmentId: 'APP1',
+                    jobTitle: 'DEV',
+                    hierarchy: createHierarchy({ department: 'IT' })
+                }),
+                createRawAppointment({
+                    appointmentId: 'APP2',
+                    jobTitle: 'MGR',
+                    hierarchy: createHierarchy({ department: 'HR' })
+                })
+            ]
 
-      // Call the method
-      const result = await appointmentService.cleanAppointments(staffNumber);
+            // Sample processed appointments (after merging/processing)
+            const processedAppointments: ProcessedAppointment[] = [
+                createProcessedAppointment({
+                    appointmentId: 'APP1',
+                    jobTitle: 'DEV',
+                    department: 'IT'
+                }),
+                createProcessedAppointment({
+                    appointmentId: 'APP2',
+                    jobTitle: 'MGR',
+                    department: 'HR'
+                })
+            ]
 
-      // Verify method calls
-      expect(appointmentService.getAppointments).toHaveBeenCalledWith(staffNumber);
-      expect(AppointmentProcessorService.processAppointments).toHaveBeenCalledWith(rawAppointments);
-      
-      // Verify result
-      expect(result.length).toBe(2);
-      expect(result[0].fullJobTitle).toBe('Software Developer');
-      expect(result[0].fullDepartment).toBe('Information Technology Department');
-      expect(result[1].fullJobTitle).toBe('Manager');
-      expect(result[1].fullDepartment).toBe('Human Resources Department');
-    });
+            // Setup mocks
+            jest.spyOn(appointmentService, 'getAppointments').mockResolvedValue(rawAppointments)
+            ;(AppointmentProcessorService.processAppointments as jest.Mock).mockReturnValue(processedAppointments)
 
-    it('should handle empty results correctly', async () => {
-      // Setup mocks for empty results
-      jest.spyOn(appointmentService, 'getAppointments').mockResolvedValue([]);
-      (AppointmentProcessorService.processAppointments as jest.Mock).mockReturnValue([]);
+            // Mock different responses for different departments/job titles
+            client.getFullDepartment.mockImplementation((dept) => {
+                if (dept === 'IT') return Promise.resolve('Information Technology Department')
+                if (dept === 'HR') return Promise.resolve('Human Resources Department')
+                return Promise.resolve(dept)
+            })
 
-      // Call the method
-      const result = await appointmentService.cleanAppointments(staffNumber);
+            client.getFullJobTitle.mockImplementation((title) => {
+                if (title === 'DEV') return Promise.resolve('Software Developer')
+                if (title === 'MGR') return Promise.resolve('Manager')
+                return Promise.resolve(title)
+            })
 
-      // Verify result
-      expect(result).toEqual([]);
-      expect(result.length).toBe(0);
-      expect(client.getFullDepartment).not.toHaveBeenCalled();
-      expect(client.getFullJobTitle).not.toHaveBeenCalled();
-    });
-  });
-});
+            // Call the method
+            const result = await appointmentService.cleanAppointments(staffNumber)
+
+            // Verify method calls
+            expect(appointmentService.getAppointments).toHaveBeenCalledWith(staffNumber)
+            expect(AppointmentProcessorService.processAppointments).toHaveBeenCalledWith(rawAppointments)
+
+            // Verify result
+            expect(result.length).toBe(2)
+            expect(result[0].fullJobTitle).toBe('Software Developer')
+            expect(result[0].fullDepartment).toBe('Information Technology Department')
+            expect(result[1].fullJobTitle).toBe('Manager')
+            expect(result[1].fullDepartment).toBe('Human Resources Department')
+        })
+
+        it('should handle empty results correctly', async () => {
+            // Setup mocks for empty results
+            jest.spyOn(appointmentService, 'getAppointments').mockResolvedValue([])
+            ;(AppointmentProcessorService.processAppointments as jest.Mock).mockReturnValue([])
+
+            // Call the method
+            const result = await appointmentService.cleanAppointments(staffNumber)
+
+            // Verify result
+            expect(result).toEqual([])
+            expect(result.length).toBe(0)
+            expect(client.getFullDepartment).not.toHaveBeenCalled()
+            expect(client.getFullJobTitle).not.toHaveBeenCalled()
+        })
+    })
+})

--- a/tests/DepartmentService.test.ts
+++ b/tests/DepartmentService.test.ts
@@ -1,163 +1,147 @@
-import { AxiosResponse, AxiosHeaders } from 'axios';
-import { DepartmentService } from '../src/DepartmentService';
-import { PeopleXdClient } from '../src/PeopleXdClient';
-import { decodeHtml } from '../src/Utilities';
+import { AxiosResponse, AxiosHeaders } from 'axios'
+import { DepartmentService } from '../src/DepartmentService'
+import { PeopleXdClient } from '../src/PeopleXdClient'
+import { decodeHtml } from '../src/Utilities'
 
-jest.mock('../src/PeopleXdClient');
-jest.mock('../src/Utilities');
+jest.mock('../src/PeopleXdClient')
+jest.mock('../src/Utilities')
 
 describe('DepartmentService', () => {
-  let client: PeopleXdClient;
-  let departmentService: DepartmentService;
+    let client: PeopleXdClient
+    let departmentService: DepartmentService
 
-  beforeEach(async () => {
-    // Mock the static new method to return a mocked instance
-    const mockClient = {
-      request: jest.fn(),
-    } as unknown as jest.Mocked<PeopleXdClient>;
-    
-    (PeopleXdClient.new as jest.Mock).mockResolvedValue(mockClient);
-    
-    // Use the static method to get an instance
-    client = await PeopleXdClient.new('https://api.example.com/', 'test-id', 'test-secret');
-    departmentService = new DepartmentService(client);
-  });
+    beforeEach(async () => {
+        // Mock the static new method to return a mocked instance
+        const mockClient = {
+            request: jest.fn()
+        } as unknown as jest.Mocked<PeopleXdClient>
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
+        ;(PeopleXdClient.new as jest.Mock).mockResolvedValue(mockClient)
 
-  describe('getDepartment method', () => {
-    it('should call client.request with the correct parameters', async () => {
-      const deptCode = 'IT_DEPT';
-      const mockResponse: AxiosResponse = {
-        data: { 
-          items: [
-            {
-              type: "DEPT",
-              code: "IT_DEPT",
-              description: "Information Technology Department",
-              active: "Y"
+        // Use the static method to get an instance
+        client = await PeopleXdClient.new('https://api.example.com/', 'test-id', 'test-secret')
+        departmentService = new DepartmentService(client)
+    })
+
+    afterEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe('getDepartment method', () => {
+        it('should call client.request with the correct parameters', async () => {
+            const deptCode = 'IT_DEPT'
+            const mockResponse: AxiosResponse = {
+                data: {
+                    items: [
+                        {
+                            type: 'DEPT',
+                            code: 'IT_DEPT',
+                            description: 'Information Technology Department',
+                            active: 'Y'
+                        }
+                    ],
+                    limit: 100,
+                    offsetby: 0,
+                    count: 1,
+                    hasMore: false
+                },
+                status: 200,
+                statusText: 'OK',
+                headers: {},
+                config: { headers: new AxiosHeaders() }
             }
-          ],
-          limit: 100,
-          offsetby: 0,
-          count: 1,
-          hasMore: false
-        },
-        status: 200,
-        statusText: 'OK',
-        headers: {},
-        config: { headers: new AxiosHeaders() }
-      };
 
-      // Setup mock for client.request
-      (client.request as jest.Mock).mockResolvedValue(mockResponse);
+            // Setup mock for client.request
+            ;(client.request as jest.Mock).mockResolvedValue(mockResponse)
 
-      // Call the method
-      const result = await departmentService.getDepartment(deptCode);
+            // Call the method
+            const result = await departmentService.getDepartment(deptCode)
 
-      // Verify client.request was called with correct parameters
-      expect(client.request).toHaveBeenCalledWith(
-        'GET', 
-        `v1/reference/type/DEPT/${deptCode}`
-      );
+            // Verify client.request was called with correct parameters
+            expect(client.request).toHaveBeenCalledWith('GET', `v1/reference/type/DEPT/${deptCode}`)
 
-      // Verify the result
-      expect(result).toEqual(mockResponse);
-    });
-  });
+            // Verify the result
+            expect(result).toEqual(mockResponse)
+        })
+    })
 
-  describe('getFullDepartment method', () => {
-    it('should return the decoded department description', async () => {
-      const deptCode = 'IT_DEPT';
-      const encodedDescription = 'Information Technology &amp; Systems';
-      const decodedDescription = 'Information Technology & Systems';
-      
-      const mockResponse: AxiosResponse = {
-        data: { 
-          items: [
-            {
-              type: "DEPT",
-              code: "IT_DEPT",
-              description: encodedDescription,
-              active: "Y"
+    describe('getFullDepartment method', () => {
+        it('should return the decoded department description', async () => {
+            const deptCode = 'IT_DEPT'
+            const encodedDescription = 'Information Technology &amp; Systems'
+            const decodedDescription = 'Information Technology & Systems'
+
+            const mockResponse: AxiosResponse = {
+                data: {
+                    items: [
+                        {
+                            type: 'DEPT',
+                            code: 'IT_DEPT',
+                            description: encodedDescription,
+                            active: 'Y'
+                        }
+                    ],
+                    limit: 100,
+                    offsetby: 0,
+                    count: 1,
+                    hasMore: false
+                },
+                status: 200,
+                statusText: 'OK',
+                headers: {},
+                config: { headers: new AxiosHeaders() }
             }
-          ],
-          limit: 100,
-          offsetby: 0,
-          count: 1,
-          hasMore: false
-        },
-        status: 200,
-        statusText: 'OK',
-        headers: {},
-        config: { headers: new AxiosHeaders() }
-      };
 
-      // Setup mocks
-      (client.request as jest.Mock).mockResolvedValue(mockResponse);
-      (decodeHtml as jest.Mock).mockReturnValue(decodedDescription);
+            // Setup mocks
+            ;(client.request as jest.Mock).mockResolvedValue(mockResponse)
+            ;(decodeHtml as jest.Mock).mockReturnValue(decodedDescription)
 
-      // Call the method
-      const result = await departmentService.getFullDepartment(deptCode);
+            // Call the method
+            const result = await departmentService.getFullDepartment(deptCode)
 
-      // Verify getDepartment was called
-      expect(client.request).toHaveBeenCalledWith(
-        'GET', 
-        `v1/reference/type/DEPT/${deptCode}`
-      );
-      
-      // Verify decodeHtml was called with the correct parameter
-      expect(decodeHtml).toHaveBeenCalledWith(encodedDescription);
-      
-      // Verify the result
-      expect(result).toBe(decodedDescription);
-    });
+            // Verify getDepartment was called
+            expect(client.request).toHaveBeenCalledWith('GET', `v1/reference/type/DEPT/${deptCode}`)
 
-    it('should handle errors properly', async () => {
-      const deptCode = 'INVALID';
-      const errorMessage = 'Resource not found';
-      
-      // Setup mock to throw an error
-      (client.request as jest.Mock).mockRejectedValue(new Error(errorMessage));
+            // Verify decodeHtml was called with the correct parameter
+            expect(decodeHtml).toHaveBeenCalledWith(encodedDescription)
 
-      // Call the method and expect it to throw
-      await expect(departmentService.getFullDepartment(deptCode))
-        .rejects
-        .toThrow(errorMessage);
-        
-      // Verify request was called with correct parameters
-      expect(client.request).toHaveBeenCalledWith(
-        'GET', 
-        `v1/reference/type/DEPT/${deptCode}`
-      );
-    });
+            // Verify the result
+            expect(result).toBe(decodedDescription)
+        })
 
-    it('should handle empty response data', async () => {
-      const deptCode = 'EMPTY';
-      
-      const mockResponse: AxiosResponse = {
-        data: { items: [] },
-        status: 200,
-        statusText: 'OK',
-        headers: {},
-        config: { headers: new AxiosHeaders() }
-      };
+        it('should handle errors properly', async () => {
+            const deptCode = 'INVALID'
+            const errorMessage = 'Resource not found'
 
-      // Setup mock
-      (client.request as jest.Mock).mockResolvedValue(mockResponse);
+            // Setup mock to throw an error
+            ;(client.request as jest.Mock).mockRejectedValue(new Error(errorMessage))
 
-      // Call the method and expect it to throw
-      await expect(departmentService.getFullDepartment(deptCode))
-        .rejects
-        .toThrow();
-        
-      // Verify request was called
-      expect(client.request).toHaveBeenCalledWith(
-        'GET', 
-        `v1/reference/type/DEPT/${deptCode}`
-      );
-    });
-  });
-});
+            // Call the method and expect it to throw
+            await expect(departmentService.getFullDepartment(deptCode)).rejects.toThrow(errorMessage)
+
+            // Verify request was called with correct parameters
+            expect(client.request).toHaveBeenCalledWith('GET', `v1/reference/type/DEPT/${deptCode}`)
+        })
+
+        it('should handle empty response data', async () => {
+            const deptCode = 'EMPTY'
+
+            const mockResponse: AxiosResponse = {
+                data: { items: [] },
+                status: 200,
+                statusText: 'OK',
+                headers: {},
+                config: { headers: new AxiosHeaders() }
+            }
+
+            // Setup mock
+            ;(client.request as jest.Mock).mockResolvedValue(mockResponse)
+
+            // Call the method and expect it to throw
+            await expect(departmentService.getFullDepartment(deptCode)).rejects.toThrow()
+
+            // Verify request was called
+            expect(client.request).toHaveBeenCalledWith('GET', `v1/reference/type/DEPT/${deptCode}`)
+        })
+    })
+})

--- a/tests/HttpClient.test.ts
+++ b/tests/HttpClient.test.ts
@@ -1,124 +1,122 @@
-import axios from 'axios';
-import { AxiosHeaders, AxiosResponse } from 'axios';
-import { HttpClient } from '../src/HttpClient';
+import axios from 'axios'
+import { AxiosHeaders, AxiosResponse } from 'axios'
+import { HttpClient } from '../src/HttpClient'
 
 // Mock axios
-jest.mock('axios');
-const mockedAxios = axios as jest.MockedFunction<typeof axios>;
+jest.mock('axios')
+const mockedAxios = axios as jest.MockedFunction<typeof axios>
 
 describe('HttpClient', () => {
-  const baseUrl = 'https://api.example.com/';
-  const token = 'test-auth-token';
-  let httpClient: HttpClient;
+    const baseUrl = 'https://api.example.com/'
+    const token = 'test-auth-token'
+    let httpClient: HttpClient
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-    httpClient = new HttpClient(baseUrl, token);
-  });
+    beforeEach(() => {
+        jest.clearAllMocks()
+        httpClient = new HttpClient(baseUrl, token)
+    })
 
-  it('should make a GET request with correct parameters', async () => {
-    const endpoint = 'users';
-    const mockResponse: AxiosResponse = {
-    data: { 
-    "items": 
-      [
-        {
-          "type": "POSTTL",
-          "code": "LIBAAL",
-          "description": "Liberal Arts Academic Lead",
-          "active": "Y"
+    it('should make a GET request with correct parameters', async () => {
+        const endpoint = 'users'
+        const mockResponse: AxiosResponse = {
+            data: {
+                items: [
+                    {
+                        type: 'POSTTL',
+                        code: 'LIBAAL',
+                        description: 'Liberal Arts Academic Lead',
+                        active: 'Y'
+                    }
+                ],
+                limit: 100,
+                offsetby: 0,
+                count: 1,
+                hasMore: false,
+                links: [
+                    {
+                        rel: 'first',
+                        href: 'https://api.corehr.com/ws/tudp/corehr/v1/reference/type/POSTTL/LIBAAL'
+                    }
+                ]
+            },
+            status: 200,
+            statusText: 'OK',
+            headers: new AxiosHeaders(),
+            config: { headers: new AxiosHeaders() }
         }
-      ],
-    "limit": 100,
-    "offsetby": 0,
-    "count": 1,
-    "hasMore": false,
-    "links": 
-      [
-        {
-          "rel": "first",
-          "href": "https://api.corehr.com/ws/tudp/corehr/v1/reference/type/POSTTL/LIBAAL"
+        // Mock axios response
+        mockedAxios.mockResolvedValueOnce(mockResponse)
+
+        // Make the request
+        const response = await httpClient.request('GET', endpoint)
+
+        // Check that axios was called with correct parameters
+        expect(axios).toHaveBeenCalledWith({
+            method: 'GET',
+            url: `${baseUrl}${endpoint}`,
+            headers: {
+                Authorization: `Bearer ${token}`,
+                'Content-Type': 'application/json'
+            },
+            data: null
+        })
+
+        // Check that the response was returned correctly
+        expect(response).toEqual(mockResponse)
+    })
+
+    it('should make a POST request with body data', async () => {
+        const endpoint = 'users'
+        const bodyData = { name: 'John Doe', email: 'john@example.com' }
+        const mockResponse: AxiosResponse = {
+            data: { id: 1, ...bodyData },
+            status: 201,
+            statusText: 'Created',
+            headers: new AxiosHeaders(),
+            config: { headers: new AxiosHeaders() }
         }
-      ]
-    },
-    status: 200,
-    statusText: 'OK',
-    headers: new AxiosHeaders(),
-    config: { headers: new AxiosHeaders() }
-    }
-    // Mock axios response
-    mockedAxios.mockResolvedValueOnce(mockResponse);
 
-    // Make the request
-    const response = await httpClient.request('GET', endpoint);
+        // Mock axios response
+        mockedAxios.mockResolvedValueOnce(mockResponse)
 
-    // Check that axios was called with correct parameters
-    expect(axios).toHaveBeenCalledWith({
-      method: 'GET',
-      url: `${baseUrl}${endpoint}`,
-      headers: {
-        'Authorization': `Bearer ${token}`,
-        'Content-Type': 'application/json'
-      },
-      data: null
-    });
+        // Make the request
+        const response = await httpClient.request('POST', endpoint, bodyData)
 
-    // Check that the response was returned correctly
-    expect(response).toEqual(mockResponse);
-  });
+        // Check that axios was called with correct parameters
+        expect(axios).toHaveBeenCalledWith({
+            method: 'POST',
+            url: `${baseUrl}${endpoint}`,
+            headers: {
+                Authorization: `Bearer ${token}`,
+                'Content-Type': 'application/json'
+            },
+            data: bodyData
+        })
 
-  it('should make a POST request with body data', async () => {
-    const endpoint = 'users';
-    const bodyData = { name: 'John Doe', email: 'john@example.com' };
-    const mockResponse: AxiosResponse = {
-      data: { id: 1, ...bodyData },
-      status: 201,
-      statusText: 'Created',
-      headers: new AxiosHeaders(),
-      config: { headers: new AxiosHeaders() }
-    };
+        // Check that the response was returned correctly
+        expect(response).toEqual(mockResponse)
+    })
 
-    // Mock axios response
-    mockedAxios.mockResolvedValueOnce(mockResponse);
+    it('should handle errors when the request fails', async () => {
+        const endpoint = 'invalid'
+        const errorMessage = 'Network Error'
+        const mockError = new Error(errorMessage)
 
-    // Make the request
-    const response = await httpClient.request('POST', endpoint, bodyData);
+        // Mock axios to throw an error
+        mockedAxios.mockRejectedValueOnce(mockError)
 
-    // Check that axios was called with correct parameters
-    expect(axios).toHaveBeenCalledWith({
-      method: 'POST',
-      url: `${baseUrl}${endpoint}`,
-      headers: {
-        'Authorization': `Bearer ${token}`,
-        'Content-Type': 'application/json'
-      },
-      data: bodyData
-    });
+        // Expect request to throw error
+        await expect(httpClient.request('GET', endpoint)).rejects.toThrow(errorMessage)
 
-    // Check that the response was returned correctly
-    expect(response).toEqual(mockResponse);
-  });
-
-  it('should handle errors when the request fails', async () => {
-    const endpoint = 'invalid';
-    const errorMessage = 'Network Error';
-    const mockError = new Error(errorMessage);
-
-    // Mock axios to throw an error
-    mockedAxios.mockRejectedValueOnce(mockError);
-
-    // Expect request to throw error
-    await expect(httpClient.request('GET', endpoint)).rejects.toThrow(errorMessage);
-
-    // Check that axios was called with correct parameters
-    expect(axios).toHaveBeenCalledWith({
-      method: 'GET',
-      url: `${baseUrl}${endpoint}`,
-      headers: {
-        'Authorization': `Bearer ${token}`,
-        'Content-Type': 'application/json'
-      },
-      data: null
-    });
-  });
-});
+        // Check that axios was called with correct parameters
+        expect(axios).toHaveBeenCalledWith({
+            method: 'GET',
+            url: `${baseUrl}${endpoint}`,
+            headers: {
+                Authorization: `Bearer ${token}`,
+                'Content-Type': 'application/json'
+            },
+            data: null
+        })
+    })
+})

--- a/tests/PeopleXdClient.test.ts
+++ b/tests/PeopleXdClient.test.ts
@@ -1,139 +1,195 @@
-import { AxiosResponse, AxiosHeaders } from 'axios';
-import { PeopleXdClient } from '../src/PeopleXdClient';
-import { TokenManagerService } from '../src/TokenManagerService';
-import { HttpClient } from '../src/HttpClient';
-import { AppointmentService } from '../src/AppointmentService';
-import { DepartmentService } from '../src/DepartmentService';
-import { PositionService } from '../src/PositionService';
-import { ProcessedAppointment } from '../src/AppointmentInterfaces';
+import { AxiosResponse, AxiosHeaders } from 'axios'
+import { PeopleXdClient, PeopleXdClientOptions } from '../src/PeopleXdClient'
+import { TokenManagerService } from '../src/TokenManagerService'
+import { HttpClient } from '../src/HttpClient'
+import { AppointmentService } from '../src/AppointmentService'
+import { DepartmentService } from '../src/DepartmentService'
+import { PositionService } from '../src/PositionService'
+import { ProcessedAppointment } from '../src/AppointmentInterfaces'
 
-jest.mock('../src/TokenManagerService');
-jest.mock('../src/HttpClient');
-jest.mock('../src/AppointmentService');
-jest.mock('../src/DepartmentService');
-jest.mock('../src/PositionService');
+jest.mock('../src/TokenManagerService')
+jest.mock('../src/HttpClient')
+jest.mock('../src/AppointmentService')
+jest.mock('../src/DepartmentService')
+jest.mock('../src/PositionService')
 
 describe('PeopleXdClient', () => {
-  const url = 'https://api.example.com/';
-  const clientId = 'test-client-id';
-  const clientSecret = 'test-client-secret';
-  const token = 'test-token';
-  let client: PeopleXdClient;
-  let httpClientMock: jest.Mocked<HttpClient>;
-
-  beforeEach(async () => {
-    // Mock TokenManagerService.new and useOrFetchToken
-    (TokenManagerService.new as jest.Mock).mockResolvedValue({
-      useOrFetchToken: jest.fn().mockResolvedValue(token)
-    });
-
-    // Create a new instance of PeopleXdClient
-    client = await PeopleXdClient.new(url, clientId, clientSecret);
-    
-    // Cast httpClient to mocked version to access mock methods
-    httpClientMock = (client as unknown as { httpClient: jest.Mocked<HttpClient> }).httpClient;
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  describe('new static method', () => {
-    it('should initialize PeopleXdClient with proper dependencies', async () => {
-      // Verify TokenManagerService was initialized correctly
-      expect(TokenManagerService.new).toHaveBeenCalledWith(url, clientId, clientSecret);
-      
-      // Verify the token was requested
-      expect(PeopleXdClient.tokenManager.useOrFetchToken).toHaveBeenCalled();
-      
-      // Verify HttpClient was constructed with correct parameters
-      expect(HttpClient).toHaveBeenCalledWith(url, token);
-      
-      // Verify services were initialized
-      expect(AppointmentService).toHaveBeenCalledWith(client);
-      expect(DepartmentService).toHaveBeenCalledWith(client);
-      expect(PositionService).toHaveBeenCalledWith(client);
-    });
-  });
-
-  describe('request method', () => {
-    it('should delegate to httpClient.request', async () => {
-      const method = 'GET';
-      const endpoint = 'test-endpoint';
-      const body = { key: 'value' };
-      const mockResponse: AxiosResponse = {
-        data: { success: true },
-        status: 200,
-        statusText: 'OK',
-        headers: {},
-        config: { headers: new AxiosHeaders() }
-      };
-
-      httpClientMock.request.mockResolvedValue(mockResponse);
-
-      const response = await client.request(method, endpoint, body);
-
-      expect(httpClientMock.request).toHaveBeenCalledWith(method, endpoint, body);
-      expect(response).toEqual(mockResponse);
-    });
-  });
-
-  describe('getFullDepartment method', () => {
-    it('should delegate to departmentService.getFullDepartment', async () => {
-      const deptCode = 'D001';
-      const fullDepartment = 'Computer Science Department';
-      
-      // Get departmentService mock and set up return value
-      const departmentServiceMock = (client as unknown as { departmentService: jest.Mocked<DepartmentService> }).departmentService;
-      departmentServiceMock.getFullDepartment.mockResolvedValue(fullDepartment);
-
-      const result = await client.getFullDepartment(deptCode);
-
-      expect(departmentServiceMock.getFullDepartment).toHaveBeenCalledWith(deptCode);
-      expect(result).toBe(fullDepartment);
-    });
-  });
-
-  describe('getFullJobTitle method', () => {
-    it('should delegate to positionService.getFullJobTitle', async () => {
-      const positionCode = 'P001';
-      const fullJobTitle = 'Senior Software Engineer';
-      
-      // Get positionService mock and set up return value
-      const positionServiceMock = (client as unknown as { positionService: jest.Mocked<PositionService> }).positionService;
-      positionServiceMock.getFullJobTitle.mockResolvedValue(fullJobTitle);
-
-      const result = await client.getFullJobTitle(positionCode);
-
-      expect(positionServiceMock.getFullJobTitle).toHaveBeenCalledWith(positionCode);
-      expect(result).toBe(fullJobTitle);
-    });
-  });
-
-  describe('cleanAppointments method', () => {
-    it('should delegate to appointmentService.cleanAppointments', async () => {
-      const staffNumber = 'S001';
-      const processedAppointments: ProcessedAppointment[] = [
-        {
-          appointmentId: '1',
-          primaryFlag: true,
-          jobTitle: 'Developer',
-          fullJobTitle: 'Software Developer',
-          department: 'IT',
-          fullDepartment: 'Information Technology',
-          startDate: '20230101',
-          endDate: '20231231'
+    const url = 'https://api.example.com/'
+    const clientId = 'test-client-id'
+    const clientSecret = 'test-client-secret'
+    const token = 'test-token'
+    let client: PeopleXdClient
+    let httpClientMock: jest.Mocked<HttpClient>
+    let positionServiceMock: jest.Mocked<PositionService>
+    const defaultOptions: PeopleXdClientOptions = {
+        titleCodeSubstitutions: {
+            HPAL: 'AL',
+            HPSL: 'SL'
         }
-      ];
-      
-      // Get appointmentService mock and set up return value
-      const appointmentServiceMock = (client as unknown as { appointmentService: jest.Mocked<AppointmentService> }).appointmentService;
-      appointmentServiceMock.cleanAppointments.mockResolvedValue(processedAppointments);
+    }
 
-      const result = await client.cleanAppointments(staffNumber);
+    beforeEach(async () => {
+        // Mock TokenManagerService.new and useOrFetchToken
+        ;(TokenManagerService.new as jest.Mock).mockResolvedValue({
+            useOrFetchToken: jest.fn().mockResolvedValue(token)
+        })
 
-      expect(appointmentServiceMock.cleanAppointments).toHaveBeenCalledWith(staffNumber);
-      expect(result).toEqual(processedAppointments);
-    });
-  });
-});
+        // Create a new instance of PeopleXdClient with options
+        client = await PeopleXdClient.new(url, clientId, clientSecret, defaultOptions)
+
+        // Cast httpClient and positionService to mocked versions to access mock methods
+        httpClientMock = (client as unknown as { httpClient: jest.Mocked<HttpClient> }).httpClient
+        positionServiceMock = (client as unknown as { positionService: jest.Mocked<PositionService> }).positionService
+    })
+
+    afterEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe('new static method', () => {
+        it('should initialize PeopleXdClient with proper dependencies', async () => {
+            // Verify TokenManagerService was initialized correctly
+            expect(TokenManagerService.new).toHaveBeenCalledWith(url, clientId, clientSecret)
+
+            // Verify the token was requested
+            expect(PeopleXdClient.tokenManager.useOrFetchToken).toHaveBeenCalled()
+
+            // Verify HttpClient was constructed with correct parameters
+            expect(HttpClient).toHaveBeenCalledWith(url, token)
+
+            // Verify services were initialized
+            expect(AppointmentService).toHaveBeenCalledWith(client)
+            expect(DepartmentService).toHaveBeenCalledWith(client)
+            expect(PositionService).toHaveBeenCalledWith(client)
+        })
+
+        it('should initialize with default options when none provided', async () => {
+            const clientNoOptions = await PeopleXdClient.new(url, clientId, clientSecret)
+            expect(clientNoOptions.getOptions()).toEqual({})
+        })
+
+        it('should initialize with provided options', async () => {
+            expect(client.getOptions()).toEqual(defaultOptions)
+        })
+    })
+
+    describe('request method', () => {
+        it('should delegate to httpClient.request', async () => {
+            const method = 'GET'
+            const endpoint = 'test-endpoint'
+            const body = { key: 'value' }
+            const mockResponse: AxiosResponse = {
+                data: { success: true },
+                status: 200,
+                statusText: 'OK',
+                headers: {},
+                config: { headers: new AxiosHeaders() }
+            }
+
+            httpClientMock.request.mockResolvedValue(mockResponse)
+
+            const response = await client.request(method, endpoint, body)
+
+            expect(httpClientMock.request).toHaveBeenCalledWith(method, endpoint, body)
+            expect(response).toEqual(mockResponse)
+        })
+    })
+
+    describe('getFullDepartment method', () => {
+        it('should delegate to departmentService.getFullDepartment', async () => {
+            const deptCode = 'D001'
+            const fullDepartment = 'Computer Science Department'
+
+            // Get departmentService mock and set up return value
+            const departmentServiceMock = (client as unknown as { departmentService: jest.Mocked<DepartmentService> })
+                .departmentService
+            departmentServiceMock.getFullDepartment.mockResolvedValue(fullDepartment)
+
+            const result = await client.getFullDepartment(deptCode)
+
+            expect(departmentServiceMock.getFullDepartment).toHaveBeenCalledWith(deptCode)
+            expect(result).toBe(fullDepartment)
+        })
+    })
+
+    describe('getFullJobTitle method', () => {
+        it('should delegate to positionService.getFullJobTitle with original code when no substitution exists', async () => {
+            const positionCode = 'P001'
+            const fullJobTitle = 'Senior Software Engineer'
+
+            positionServiceMock.getFullJobTitle.mockResolvedValue(fullJobTitle)
+
+            const result = await client.getFullJobTitle(positionCode)
+
+            expect(positionServiceMock.getFullJobTitle).toHaveBeenCalledWith(positionCode)
+            expect(result).toBe(fullJobTitle)
+        })
+
+        it('should use substituted code when one exists', async () => {
+            const originalCode = 'HPAL'
+            const substitutedCode = 'AL'
+            const fullJobTitle = 'Assistant Lecturer'
+
+            positionServiceMock.getFullJobTitle.mockResolvedValue(fullJobTitle)
+
+            const result = await client.getFullJobTitle(originalCode)
+
+            // Should call with the substituted code
+            expect(positionServiceMock.getFullJobTitle).toHaveBeenCalledWith(substitutedCode)
+            expect(positionServiceMock.getFullJobTitle).not.toHaveBeenCalledWith(originalCode)
+            expect(result).toBe(fullJobTitle)
+        })
+
+        it('should handle multiple different substitutions correctly', async () => {
+            // Test first substitution
+            positionServiceMock.getFullJobTitle.mockResolvedValueOnce('Assistant Lecturer')
+            await client.getFullJobTitle('HPAL')
+            expect(positionServiceMock.getFullJobTitle).toHaveBeenNthCalledWith(1, 'AL')
+
+            // Test second substitution
+            positionServiceMock.getFullJobTitle.mockResolvedValueOnce('Senior Lecturer')
+            await client.getFullJobTitle('HPSL')
+            expect(positionServiceMock.getFullJobTitle).toHaveBeenNthCalledWith(2, 'SL')
+        })
+    })
+
+    describe('getOptions method', () => {
+        it('should return the client options', () => {
+            const options = client.getOptions()
+            expect(options).toEqual(defaultOptions)
+
+            // Verify it's a copy and not the original reference
+            options.titleCodeSubstitutions = {}
+            expect(client.getOptions()).toEqual(defaultOptions)
+        })
+    })
+
+    describe('cleanAppointments method', () => {
+        it('should delegate to appointmentService.cleanAppointments', async () => {
+            const staffNumber = 'S001'
+            const processedAppointments: ProcessedAppointment[] = [
+                {
+                    appointmentId: '1',
+                    primaryFlag: true,
+                    jobTitle: 'Developer',
+                    fullJobTitle: 'Software Developer',
+                    department: 'IT',
+                    fullDepartment: 'Information Technology',
+                    startDate: '20230101',
+                    endDate: '20231231'
+                }
+            ]
+
+            // Get appointmentService mock and set up return value
+            const appointmentServiceMock = (
+                client as unknown as { appointmentService: jest.Mocked<AppointmentService> }
+            ).appointmentService
+            appointmentServiceMock.cleanAppointments.mockResolvedValue(processedAppointments)
+
+            const result = await client.cleanAppointments(staffNumber)
+
+            expect(appointmentServiceMock.cleanAppointments).toHaveBeenCalledWith(staffNumber)
+            expect(result).toEqual(processedAppointments)
+        })
+    })
+})

--- a/tests/PositionService.test.ts
+++ b/tests/PositionService.test.ts
@@ -1,165 +1,148 @@
-import { AxiosResponse, AxiosHeaders } from 'axios';
-import { PositionService } from '../src/PositionService';
-import { PeopleXdClient } from '../src/PeopleXdClient';
-import { decodeHtml } from '../src/Utilities';
+import { AxiosResponse, AxiosHeaders } from 'axios'
+import { PositionService } from '../src/PositionService'
+import { PeopleXdClient } from '../src/PeopleXdClient'
+import { decodeHtml } from '../src/Utilities'
 
-jest.mock('../src/PeopleXdClient');
-jest.mock('../src/Utilities');
+jest.mock('../src/PeopleXdClient')
+jest.mock('../src/Utilities')
 
 describe('PositionService', () => {
-  let client: PeopleXdClient;
-  let positionService: PositionService;
+    let client: PeopleXdClient
+    let positionService: PositionService
 
+    beforeEach(async () => {
+        // Mock the static new method to return a mocked instance
+        const mockClient = {
+            request: jest.fn()
+            // Add any other methods/properties your tests need
+        } as unknown as jest.Mocked<PeopleXdClient>
 
-  beforeEach(async () => {
-    // Mock the static new method to return a mocked instance
-    const mockClient = {
-      request: jest.fn(),
-      // Add any other methods/properties your tests need
-    } as unknown as jest.Mocked<PeopleXdClient>;
-    
-    (PeopleXdClient.new as jest.Mock).mockResolvedValue(mockClient);
-    
-    // Use the static method to get an instance
-    client = await PeopleXdClient.new('https://api.example.com/', 'test-id', 'test-secret');
-    positionService = new PositionService(client);
-  });
+        ;(PeopleXdClient.new as jest.Mock).mockResolvedValue(mockClient)
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
+        // Use the static method to get an instance
+        client = await PeopleXdClient.new('https://api.example.com/', 'test-id', 'test-secret')
+        positionService = new PositionService(client)
+    })
 
-  describe('getPositionTitle method', () => {
-    it('should call client.request with the correct parameters', async () => {
-      const positionCode = 'LIBAAL';
-      const mockResponse: AxiosResponse = {
-        data: { 
-          items: [
-            {
-              type: "POSTTL",
-              code: "LIBAAL",
-              description: "Liberal Arts Academic Lead",
-              active: "Y"
+    afterEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe('getPositionTitle method', () => {
+        it('should call client.request with the correct parameters', async () => {
+            const positionCode = 'LIBAAL'
+            const mockResponse: AxiosResponse = {
+                data: {
+                    items: [
+                        {
+                            type: 'POSTTL',
+                            code: 'LIBAAL',
+                            description: 'Liberal Arts Academic Lead',
+                            active: 'Y'
+                        }
+                    ],
+                    limit: 100,
+                    offsetby: 0,
+                    count: 1,
+                    hasMore: false
+                },
+                status: 200,
+                statusText: 'OK',
+                headers: {},
+                config: { headers: new AxiosHeaders() }
             }
-          ],
-          limit: 100,
-          offsetby: 0,
-          count: 1,
-          hasMore: false
-        },
-        status: 200,
-        statusText: 'OK',
-        headers: {},
-        config: { headers: new AxiosHeaders() }
-      };
 
-      // Setup mock for client.request
-      (client.request as jest.Mock).mockResolvedValue(mockResponse);
+            // Setup mock for client.request
+            ;(client.request as jest.Mock).mockResolvedValue(mockResponse)
 
-      // Call the method
-      const result = await positionService.getPositionTitle(positionCode);
+            // Call the method
+            const result = await positionService.getPositionTitle(positionCode)
 
-      // Verify client.request was called with correct parameters
-      expect(client.request).toHaveBeenCalledWith(
-        'GET', 
-        `v1/reference/type/POSTTL/${positionCode}`
-      );
+            // Verify client.request was called with correct parameters
+            expect(client.request).toHaveBeenCalledWith('GET', `v1/reference/type/POSTTL/${positionCode}`)
 
-      // Verify the result
-      expect(result).toEqual(mockResponse);
-    });
-  });
+            // Verify the result
+            expect(result).toEqual(mockResponse)
+        })
+    })
 
-  describe('getFullJobTitle method', () => {
-    it('should return the decoded job title', async () => {
-      const positionCode = 'LIBAAL';
-      const encodedTitle = 'Liberal Arts Academic &amp; Lead';
-      const decodedTitle = 'Liberal Arts Academic & Lead';
-      
-      const mockResponse: AxiosResponse = {
-        data: { 
-          items: [
-            {
-              type: "POSTTL",
-              code: "LIBAAL",
-              description: encodedTitle,
-              active: "Y"
+    describe('getFullJobTitle method', () => {
+        it('should return the decoded job title', async () => {
+            const positionCode = 'LIBAAL'
+            const encodedTitle = 'Liberal Arts Academic &amp; Lead'
+            const decodedTitle = 'Liberal Arts Academic & Lead'
+
+            const mockResponse: AxiosResponse = {
+                data: {
+                    items: [
+                        {
+                            type: 'POSTTL',
+                            code: 'LIBAAL',
+                            description: encodedTitle,
+                            active: 'Y'
+                        }
+                    ],
+                    limit: 100,
+                    offsetby: 0,
+                    count: 1,
+                    hasMore: false
+                },
+                status: 200,
+                statusText: 'OK',
+                headers: {},
+                config: { headers: new AxiosHeaders() }
             }
-          ],
-          limit: 100,
-          offsetby: 0,
-          count: 1,
-          hasMore: false
-        },
-        status: 200,
-        statusText: 'OK',
-        headers: {},
-        config: { headers: new AxiosHeaders() }
-      };
 
-      // Setup mocks
-      (client.request as jest.Mock).mockResolvedValue(mockResponse);
-      (decodeHtml as jest.Mock).mockReturnValue(decodedTitle);
+            // Setup mocks
+            ;(client.request as jest.Mock).mockResolvedValue(mockResponse)
+            ;(decodeHtml as jest.Mock).mockReturnValue(decodedTitle)
 
-      // Call the method
-      const result = await positionService.getFullJobTitle(positionCode);
+            // Call the method
+            const result = await positionService.getFullJobTitle(positionCode)
 
-      // Verify getPositionTitle was called
-      expect(client.request).toHaveBeenCalledWith(
-        'GET', 
-        `v1/reference/type/POSTTL/${positionCode}`
-      );
-      
-      // Verify decodeHtml was called with the correct parameter
-      expect(decodeHtml).toHaveBeenCalledWith(encodedTitle);
-      
-      // Verify the result
-      expect(result).toBe(decodedTitle);
-    });
+            // Verify getPositionTitle was called
+            expect(client.request).toHaveBeenCalledWith('GET', `v1/reference/type/POSTTL/${positionCode}`)
 
-    it('should handle errors properly', async () => {
-      const positionCode = 'INVALID';
-      const errorMessage = 'Resource not found';
-      
-      // Setup mock to throw an error
-      (client.request as jest.Mock).mockRejectedValue(new Error(errorMessage));
+            // Verify decodeHtml was called with the correct parameter
+            expect(decodeHtml).toHaveBeenCalledWith(encodedTitle)
 
-      // Call the method and expect it to throw
-      await expect(positionService.getFullJobTitle(positionCode))
-        .rejects
-        .toThrow(errorMessage);
-        
-      // Verify request was called with correct parameters
-      expect(client.request).toHaveBeenCalledWith(
-        'GET', 
-        `v1/reference/type/POSTTL/${positionCode}`
-      );
-    });
+            // Verify the result
+            expect(result).toBe(decodedTitle)
+        })
 
-    it('should handle empty response data', async () => {
-      const positionCode = 'EMPTY';
-      
-      const mockResponse: AxiosResponse = {
-        data: { items: [] },
-        status: 200,
-        statusText: 'OK',
-        headers: {},
-        config: { headers: new AxiosHeaders() }
-      };
+        it('should handle errors properly', async () => {
+            const positionCode = 'INVALID'
+            const errorMessage = 'Resource not found'
 
-      // Setup mock
-      (client.request as jest.Mock).mockResolvedValue(mockResponse);
+            // Setup mock to throw an error
+            ;(client.request as jest.Mock).mockRejectedValue(new Error(errorMessage))
 
-      // Call the method and expect it to throw
-      await expect(positionService.getFullJobTitle(positionCode))
-        .rejects
-        .toThrow();
-        
-      // Verify request was called
-      expect(client.request).toHaveBeenCalledWith(
-        'GET', 
-        `v1/reference/type/POSTTL/${positionCode}`
-      );
-    });
-  });
-});
+            // Call the method and expect it to throw
+            await expect(positionService.getFullJobTitle(positionCode)).rejects.toThrow(errorMessage)
+
+            // Verify request was called with correct parameters
+            expect(client.request).toHaveBeenCalledWith('GET', `v1/reference/type/POSTTL/${positionCode}`)
+        })
+
+        it('should handle empty response data', async () => {
+            const positionCode = 'EMPTY'
+
+            const mockResponse: AxiosResponse = {
+                data: { items: [] },
+                status: 200,
+                statusText: 'OK',
+                headers: {},
+                config: { headers: new AxiosHeaders() }
+            }
+
+            // Setup mock
+            ;(client.request as jest.Mock).mockResolvedValue(mockResponse)
+
+            // Call the method and expect it to throw
+            await expect(positionService.getFullJobTitle(positionCode)).rejects.toThrow()
+
+            // Verify request was called
+            expect(client.request).toHaveBeenCalledWith('GET', `v1/reference/type/POSTTL/${positionCode}`)
+        })
+    })
+})

--- a/tests/TokenManagerService.test.ts
+++ b/tests/TokenManagerService.test.ts
@@ -1,94 +1,93 @@
-import fs from 'fs';
-import path from 'path';
-import axios from 'axios';
-import timekeeper from 'timekeeper';
-import MockAdapter from 'axios-mock-adapter';
-import { TokenManagerService } from '../src/TokenManagerService';
+import fs from 'fs'
+import path from 'path'
+import axios from 'axios'
+import timekeeper from 'timekeeper'
+import MockAdapter from 'axios-mock-adapter'
+import { TokenManagerService } from '../src/TokenManagerService'
 
-const TMP_DIR = 'tmp';
-const CACHE_TOKEN_FILE = 'cache_token';
+const TMP_DIR = 'tmp'
+const CACHE_TOKEN_FILE = 'cache_token'
 
-
-jest.mock('fs');
-jest.mock('path');
+jest.mock('fs')
+jest.mock('path')
 
 describe('TokenManagerService', () => {
-    const url = 'https://example.com/';
-    const clientId = 'test-client-id';
-    const clientSecret = 'test-client-secret';
-    let mock: MockAdapter;
+    const url = 'https://example.com/'
+    const clientId = 'test-client-id'
+    const clientSecret = 'test-client-secret'
+    let mock: MockAdapter
 
     beforeEach(() => {
-        mock = new MockAdapter(axios);
-        timekeeper.freeze(new Date('2025-01-01'));
-        jest.clearAllMocks();
-    });
+        mock = new MockAdapter(axios)
+        timekeeper.freeze(new Date('2025-01-01'))
+        jest.clearAllMocks()
+    })
 
     afterEach(() => {
-        mock.restore();
-        timekeeper.reset();
-    });
+        mock.restore()
+        timekeeper.reset()
+    })
 
     it('should fetch a new token if no cached token is available', async () => {
         const tokenResponse = {
             access_token: 'new-access-token',
             expires_in: 3600
-        };
+        }
 
-        mock.onPost(`${url}oauth/token`).reply(200, tokenResponse);
+        mock.onPost(`${url}oauth/token`).reply(200, tokenResponse)
 
-        const tokenManager = await TokenManagerService.new(url, clientId, clientSecret);
+        const tokenManager = await TokenManagerService.new(url, clientId, clientSecret)
 
-        expect(tokenManager).toBeDefined();
-        expect(tokenManager.useOrFetchToken()).resolves.toBe('new-access-token');
-    });
+        expect(tokenManager).toBeDefined()
+        expect(tokenManager.useOrFetchToken()).resolves.toBe('new-access-token')
+    })
 
     it('should use the cached token if it is not expired', async () => {
         const cachedToken = {
             access_token: 'cached-access-token',
             expires_at: new Date(Date.now() + 3600 * 1000).toISOString()
-        };
+        }
 
-        (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify(cachedToken));
+        ;(fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify(cachedToken))
 
-        const tokenManager = await TokenManagerService.new(url, clientId, clientSecret);
+        const tokenManager = await TokenManagerService.new(url, clientId, clientSecret)
 
-        expect(tokenManager).toBeDefined();
-        expect(tokenManager.useOrFetchToken()).resolves.toBe('cached-access-token');
-    });
+        expect(tokenManager).toBeDefined()
+        expect(tokenManager.useOrFetchToken()).resolves.toBe('cached-access-token')
+    })
 
     it('should fetch a new token if the cached token is expired', async () => {
         const expiredToken = {
             access_token: 'expired-access-token',
             expires_at: new Date(Date.now() - 3600 * 1000).toISOString()
-        };
+        }
 
         const tokenResponse = {
             access_token: 'new-access-token',
             expires_in: 3600
-        };
+        }
 
-        (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify(expiredToken));
-        mock.onPost(`${url}oauth/token`).reply(200, tokenResponse);
+        ;(fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify(expiredToken))
+        mock.onPost(`${url}oauth/token`).reply(200, tokenResponse)
 
-        const tokenManager = await TokenManagerService.new(url, clientId, clientSecret);
+        const tokenManager = await TokenManagerService.new(url, clientId, clientSecret)
 
-        expect(tokenManager).toBeDefined();
-        expect(tokenManager.useOrFetchToken()).resolves.toBe('new-access-token');
-    });
+        expect(tokenManager).toBeDefined()
+        expect(tokenManager.useOrFetchToken()).resolves.toBe('new-access-token')
+    })
 
     it('should cache the token after fetching a new one', async () => {
         const tokenResponse = {
             access_token: 'new-access-token',
             expires_in: 3600
-        };
+        }
 
-        mock.onPost(`${url}oauth/token`).reply(200, tokenResponse);
+        mock.onPost(`${url}oauth/token`).reply(200, tokenResponse)
 
-        const tokenManager = await TokenManagerService.new(url, clientId, clientSecret);
+        const tokenManager = await TokenManagerService.new(url, clientId, clientSecret)
 
-        expect(tokenManager).toBeDefined();
-        await tokenManager.useOrFetchToken();
+        expect(tokenManager).toBeDefined()
+        await tokenManager.useOrFetchToken()
 
         expect(fs.writeFileSync).toHaveBeenCalledWith(
             path.join(TMP_DIR, CACHE_TOKEN_FILE),
@@ -96,12 +95,14 @@ describe('TokenManagerService', () => {
                 access_token: 'new-access-token',
                 expires_at: new Date(Date.now() + 3540 * 1000).toISOString()
             })
-        );
-    });
+        )
+    })
 
     it('should handle errors when fetching a new token', async () => {
-        mock.onPost(`${url}oauth/token`).reply(500);
+        mock.onPost(`${url}oauth/token`).reply(500)
 
-        await expect(TokenManagerService.new(url, clientId, clientSecret)).rejects.toThrow('Request failed with status code 500');
-    });
-});
+        await expect(TokenManagerService.new(url, clientId, clientSecret)).rejects.toThrow(
+            'Request failed with status code 500'
+        )
+    })
+})

--- a/tests/Utilities.test.ts
+++ b/tests/Utilities.test.ts
@@ -1,54 +1,54 @@
-import { decodeHtml } from '../src/Utilities';
-import { decode } from 'html-entities';
+import { decodeHtml } from '../src/Utilities'
+import { decode } from 'html-entities'
 
 // Mock the html-entities package
 jest.mock('html-entities', () => ({
-  decode: jest.fn()
-}));
+    decode: jest.fn()
+}))
 
 describe('Utilities', () => {
-  describe('decodeHtml', () => {
-    beforeEach(() => {
-      // Clear mock calls before each test
-      jest.clearAllMocks();
-      
-      // Set up the mock to pass through the input by default
-      (decode as jest.Mock).mockImplementation((text) => text);
-    });
+    describe('decodeHtml', () => {
+        beforeEach(() => {
+            // Clear mock calls before each test
+            jest.clearAllMocks()
 
-    it('should call the decode function from html-entities', () => {
-      const text = 'Test &amp; example';
-      decodeHtml(text);
-      
-      expect(decode).toHaveBeenCalledWith(text);
-      expect(decode).toHaveBeenCalledTimes(1);
-    });
+            // Set up the mock to pass through the input by default
+            ;(decode as jest.Mock).mockImplementation((text) => text)
+        })
 
-    it('should return the decoded string', () => {
-      const input = 'This &amp; that';
-      const expected = 'This & that';
-      
-      (decode as jest.Mock).mockReturnValue(expected);
-      
-      const result = decodeHtml(input);
-      
-      expect(result).toBe(expected);
-    });
+        it('should call the decode function from html-entities', () => {
+            const text = 'Test &amp; example'
+            decodeHtml(text)
 
-    it('should handle empty strings', () => {
-      const input = '';
-      const result = decodeHtml(input);
-      
-      expect(decode).toHaveBeenCalledWith('');
-      expect(result).toBe('');
-    });
+            expect(decode).toHaveBeenCalledWith(text)
+            expect(decode).toHaveBeenCalledTimes(1)
+        })
 
-    it('should handle strings without HTML entities', () => {
-      const input = 'Plain text without entities';
-      
-      decodeHtml(input);
-      
-      expect(decode).toHaveBeenCalledWith(input);
-    });
-  });
-});
+        it('should return the decoded string', () => {
+            const input = 'This &amp; that'
+            const expected = 'This & that'
+
+            ;(decode as jest.Mock).mockReturnValue(expected)
+
+            const result = decodeHtml(input)
+
+            expect(result).toBe(expected)
+        })
+
+        it('should handle empty strings', () => {
+            const input = ''
+            const result = decodeHtml(input)
+
+            expect(decode).toHaveBeenCalledWith('')
+            expect(result).toBe('')
+        })
+
+        it('should handle strings without HTML entities', () => {
+            const input = 'Plain text without entities'
+
+            decodeHtml(input)
+
+            expect(decode).toHaveBeenCalledWith(input)
+        })
+    })
+})

--- a/tests/fixtures/AppointmentFixturesFactory.ts
+++ b/tests/fixtures/AppointmentFixturesFactory.ts
@@ -1,84 +1,84 @@
-import { RawAppointment, ProcessedAppointment, Hierarchy } from '../../src/AppointmentInterfaces';
+import { RawAppointment, ProcessedAppointment, Hierarchy } from '../../src/AppointmentInterfaces'
 /**
  * Creates a hierarchy object with default values that can be partially overridden
  */
 export function createHierarchy(overrides: Partial<Hierarchy> = {}): Hierarchy {
-  return {
-    structureCode: 'STR001',
-    company: 'ACME Inc',
-    managementUnit: 'IT Department',
-    department: 'Software Development',
-    costCentre: 'COST123',
-    division: 'Digital',
-    location: 'Headquarters',
-    workGroup: 'Engineering',
-    user1: '',
-    user2: '',
-    user3: '',
-    user4: '',
-    user5: '',
-    ...overrides
-  };
+    return {
+        structureCode: 'STR001',
+        company: 'ACME Inc',
+        managementUnit: 'IT Department',
+        department: 'Software Development',
+        costCentre: 'COST123',
+        division: 'Digital',
+        location: 'Headquarters',
+        workGroup: 'Engineering',
+        user1: '',
+        user2: '',
+        user3: '',
+        user4: '',
+        user5: '',
+        ...overrides
+    }
 }
 
 /**
  * Creates a standard RawAppointment fixture with customizable properties
  */
 export function createRawAppointment(overrides: Partial<RawAppointment> = {}): RawAppointment {
-  return {
-    appointmentId: '12345',
-    appointmentStatus: 'ACTIVE',
-    employeeStatus: 'CURRENT',
-    jobDescription: 'Software Developer',
-    primaryFlag: 'Y',
-    category: 'FULLTIME',
-    subCategory: 'PERMANENT',
-    startDate: '20230101',
-    endDate: '20231231',
-    lastAmendedDate: '20230115',
-    targetEndDate: '20231231',
-    FTE: '1.0',
-    contractId: 'CONT123',
-    jobTitle: 'SOFTWARE_DEV',
-    jobCategory: 'IT',
-    project: 'CORE_SYS',
-    postNumber: 'POST123',
-    reasonCode: 'NEW_HIRE',
-    action: 'HIRE',
-    hierarchy: {
-      structureCode: 'STR001',
-      company: 'ACME Inc',
-      managementUnit: 'IT Department',
-      department: 'Software Development',
-      costCentre: 'COST123',
-      division: 'Digital',
-      location: 'Headquarters',
-      workGroup: 'Engineering',
-      user1: '',
-      user2: '',
-      user3: '',
-      user4: '',
-      user5: ''
-    },
-    ...overrides
-  };
+    return {
+        appointmentId: '12345',
+        appointmentStatus: 'ACTIVE',
+        employeeStatus: 'CURRENT',
+        jobDescription: 'Software Developer',
+        primaryFlag: 'Y',
+        category: 'FULLTIME',
+        subCategory: 'PERMANENT',
+        startDate: '20230101',
+        endDate: '20231231',
+        lastAmendedDate: '20230115',
+        targetEndDate: '20231231',
+        FTE: '1.0',
+        contractId: 'CONT123',
+        jobTitle: 'SOFTWARE_DEV',
+        jobCategory: 'IT',
+        project: 'CORE_SYS',
+        postNumber: 'POST123',
+        reasonCode: 'NEW_HIRE',
+        action: 'HIRE',
+        hierarchy: {
+            structureCode: 'STR001',
+            company: 'ACME Inc',
+            managementUnit: 'IT Department',
+            department: 'Software Development',
+            costCentre: 'COST123',
+            division: 'Digital',
+            location: 'Headquarters',
+            workGroup: 'Engineering',
+            user1: '',
+            user2: '',
+            user3: '',
+            user4: '',
+            user5: ''
+        },
+        ...overrides
+    }
 }
 
 /**
  * Creates a standard ProcessedAppointment fixture with customizable properties
  */
 export function createProcessedAppointment(overrides: Partial<ProcessedAppointment> = {}): ProcessedAppointment {
-  return {
-    appointmentId: '12345',
-    primaryFlag: true,
-    jobTitle: 'SOFTWARE_DEV',
-    fullJobTitle: 'Software Developer',
-    department: 'Software Development',
-    fullDepartment: 'Software Development Division',
-    startDate: '20230101',
-    endDate: '20231231',
-    ...overrides
-  };
+    return {
+        appointmentId: '12345',
+        primaryFlag: true,
+        jobTitle: 'SOFTWARE_DEV',
+        fullJobTitle: 'Software Developer',
+        department: 'Software Development',
+        fullDepartment: 'Software Development Division',
+        startDate: '20230101',
+        endDate: '20231231',
+        ...overrides
+    }
 }
 
 /**
@@ -88,90 +88,90 @@ export function createProcessedAppointment(overrides: Partial<ProcessedAppointme
  * @returns Array of raw appointments
  */
 export function createSequentialRawAppointments(
-  count: number, 
-  baseDate: string = '20230101',
-  baseProps: Partial<RawAppointment> = {}
+    count: number,
+    baseDate: string = '20230101',
+    baseProps: Partial<RawAppointment> = {}
 ): RawAppointment[] {
-  const appointments: RawAppointment[] = [];
-  
-  for (let i = 0; i < count; i++) {
-    // Calculate dates by adding months to the base date
-    const startYear = parseInt(baseDate.substring(0, 4));
-    const startMonth = parseInt(baseDate.substring(4, 6)) + (i * 3); // Add 3 months per appointment
-    const startDay = baseDate.substring(6, 8);
-    
-    let adjustedYear = startYear + Math.floor((startMonth - 1) / 12);
-    let adjustedMonth = ((startMonth - 1) % 12) + 1;
-    
-    const formattedMonth = adjustedMonth.toString().padStart(2, '0');
-    const startDate = `${adjustedYear}${formattedMonth}${startDay}`;
-    
-    // End date is 3 months after start
-    adjustedMonth = adjustedMonth + 2;
-    if (adjustedMonth > 12) {
-      adjustedYear += 1;
-      adjustedMonth -= 12;
+    const appointments: RawAppointment[] = []
+
+    for (let i = 0; i < count; i++) {
+        // Calculate dates by adding months to the base date
+        const startYear = parseInt(baseDate.substring(0, 4))
+        const startMonth = parseInt(baseDate.substring(4, 6)) + i * 3 // Add 3 months per appointment
+        const startDay = baseDate.substring(6, 8)
+
+        let adjustedYear = startYear + Math.floor((startMonth - 1) / 12)
+        let adjustedMonth = ((startMonth - 1) % 12) + 1
+
+        const formattedMonth = adjustedMonth.toString().padStart(2, '0')
+        const startDate = `${adjustedYear}${formattedMonth}${startDay}`
+
+        // End date is 3 months after start
+        adjustedMonth = adjustedMonth + 2
+        if (adjustedMonth > 12) {
+            adjustedYear += 1
+            adjustedMonth -= 12
+        }
+        const formattedEndMonth = adjustedMonth.toString().padStart(2, '0')
+        const endDate = `${adjustedYear}${formattedEndMonth}${startDay}`
+
+        appointments.push(
+            createRawAppointment({
+                appointmentId: `APP${i + 1}`,
+                startDate,
+                endDate,
+                ...baseProps
+            })
+        )
     }
-    const formattedEndMonth = adjustedMonth.toString().padStart(2, '0');
-    const endDate = `${adjustedYear}${formattedEndMonth}${startDay}`;
-    
-    appointments.push(createRawAppointment({
-      appointmentId: `APP${i + 1}`,
-      startDate,
-      endDate,
-      ...baseProps
-    }));
-  }
-  
-  return appointments;
+
+    return appointments
 }
 
 /**
  * Creates a pair of appointments for testing merging logic
  */
-export function createMergeableAppointmentPair(
-  shouldMerge: boolean = true,
-  daysBetween: number = 1
-): RawAppointment[] {
-  const firstAppointment = createRawAppointment({
-    appointmentId: 'APP1',
-    startDate: '20230101',
-    endDate: '20230331',
-    jobTitle: 'SOFTWARE_DEV',
-    hierarchy: {
-      ...createRawAppointment().hierarchy,
-      department: 'Software Development'
-    }
-  });
-  
-  // Calculate second appointment start date based on daysBetween
-  const firstEndDate = new Date(
-    parseInt(firstAppointment.endDate.substring(0, 4)),
-    parseInt(firstAppointment.endDate.substring(4, 6)) - 1,
-    parseInt(firstAppointment.endDate.substring(6, 8))
-  );
-  
-  const secondStartDate = new Date(firstEndDate);
-  secondStartDate.setDate(secondStartDate.getDate() + daysBetween);
-  
-  const formattedSecondStartDate = secondStartDate.toISOString().split('T')[0].replace(/-/g, '');
-  
-  // Calculate second appointment end date (3 months after start)
-  const secondEndDate = new Date(secondStartDate);
-  secondEndDate.setMonth(secondEndDate.getMonth() + 3);
-  
-  const formattedSecondEndDate = secondEndDate.toISOString().split('T')[0].replace(/-/g, '');
-  
-  const secondAppointment = createRawAppointment({
-    appointmentId: 'APP2',
-    startDate: formattedSecondStartDate,
-    endDate: formattedSecondEndDate,
-    // If shouldMerge is false, change either job title or department
-    ...(shouldMerge ? {} : Math.random() > 0.5 ? 
-      { jobTitle: 'MANAGER' } : 
-      { hierarchy: { ...firstAppointment.hierarchy, department: 'Human Resources' } }
+export function createMergeableAppointmentPair(shouldMerge: boolean = true, daysBetween: number = 1): RawAppointment[] {
+    const firstAppointment = createRawAppointment({
+        appointmentId: 'APP1',
+        startDate: '20230101',
+        endDate: '20230331',
+        jobTitle: 'SOFTWARE_DEV',
+        hierarchy: {
+            ...createRawAppointment().hierarchy,
+            department: 'Software Development'
+        }
+    })
+
+    // Calculate second appointment start date based on daysBetween
+    const firstEndDate = new Date(
+        parseInt(firstAppointment.endDate.substring(0, 4)),
+        parseInt(firstAppointment.endDate.substring(4, 6)) - 1,
+        parseInt(firstAppointment.endDate.substring(6, 8))
     )
-  });
-  
-  return [firstAppointment, secondAppointment];
+
+    const secondStartDate = new Date(firstEndDate)
+    secondStartDate.setDate(secondStartDate.getDate() + daysBetween)
+
+    const formattedSecondStartDate = secondStartDate.toISOString().split('T')[0].replace(/-/g, '')
+
+    // Calculate second appointment end date (3 months after start)
+    const secondEndDate = new Date(secondStartDate)
+    secondEndDate.setMonth(secondEndDate.getMonth() + 3)
+
+    const formattedSecondEndDate = secondEndDate.toISOString().split('T')[0].replace(/-/g, '')
+
+    const secondAppointment = createRawAppointment({
+        appointmentId: 'APP2',
+        startDate: formattedSecondStartDate,
+        endDate: formattedSecondEndDate,
+        // If shouldMerge is false, change either job title or department
+        ...(shouldMerge
+            ? {}
+            : Math.random() > 0.5
+              ? { jobTitle: 'MANAGER' }
+              : { hierarchy: { ...firstAppointment.hierarchy, department: 'Human Resources' } })
+    })
+
+    return [firstAppointment, secondAppointment]
 }


### PR DESCRIPTION
This PR adds a configuration option to the `PeopleXdClient` which allows for Job Title code substitution as outlined in #12.

It updates the `README.md` and `dummy_proj/main.js` to refer to and use the configuration respectively.