### PR TITLE
fix: preserve primaryFlag when mergin
g appointments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,11 +72,8 @@ jobs:
           - name: Install Dependancies
             run: npm install -g npm@latest
           - run: npm install
-<<<<<<< HEAD
-=======
           - name: Build Package
             run: npm run build
->>>>>>> 9c83c7e (upgrade npm on publish)
           - name: Publish
             run: npm publish --tag next --tag next --provenance --access public
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,13 @@ jobs:
           - name: Install Dependancies
             run: npm install -g npm@latest
           - run: npm install
+<<<<<<< HEAD
+=======
+          - name: Build Package
+            run: npm run build
+>>>>>>> 9c83c7e (upgrade npm on publish)
           - name: Publish
-            run: npm publish --tag next --provenance --access public
+            run: npm publish --tag next --tag next --provenance --access public
 
   dry-run-publish:
       needs: build
@@ -91,6 +96,8 @@ jobs:
                 always-auth: true
           - name: Install Dependancies
             run: npm install
+          - name: Build Package
+            run: npm run build
           - name: Dry-run Publish
             run: npm publish --provenance --access public --dry-run
           - name: Pack Artifact

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "peoplexd-client",
-  "version": "0.0.9-beta",
+  "version": "0.0.10-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "peoplexd-client",
-      "version": "0.0.9-beta",
+      "version": "0.0.10-beta",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "peoplexd-client",
-  "version": "0.0.9-beta",
+  "version": "0.0.10-beta",
   "description": "A TypeScript application to interact with the PeopleXd API",
   "main": "./dist/index.cjs",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "start": "node dummy_proj/main.js",
     "build": "tsup",
+    "prepublishOnly": "npm run build",
     "test": "jest",
     "format": "prettier --write .",
     "lint": "eslint . ",

--- a/src/AppointmentProcessorService.ts
+++ b/src/AppointmentProcessorService.ts
@@ -119,6 +119,7 @@ export class AppointmentProcessorService {
         nextAppointment: RawAppointment
     ): ProcessedAppointment {
         currentAppointment.endDate = this.getLaterDate(currentAppointment.endDate, nextAppointment.endDate)
+        currentAppointment.primaryFlag = currentAppointment.primaryFlag || nextAppointment.primaryFlag === 'Y'
         return currentAppointment
     }
 }

--- a/tests/AppointmentProcessorService.test.ts
+++ b/tests/AppointmentProcessorService.test.ts
@@ -56,5 +56,61 @@ describe('AppointmentProcessorService', () => {
             // Should not merge
             expect(result.length).toBe(2)
         })
+
+        it('should preserve primaryFlag when merging appointments where later appointment is primary', () => {
+            // First appointment is not primary, second is primary
+            const rawAppointments = [
+                createRawAppointment({
+                    appointmentId: 'APP1',
+                    primaryFlag: 'N',
+                    startDate: '20231121',
+                    endDate: '20241124',
+                    jobTitle: 'ASTLE',
+                    hierarchy: { structureCode: '2', company: '1', managementUnit: 'SH', department: 'SH06', costCentre: 'DL29', division: '1', location: '77', workGroup: 'SC02', user1: '', user2: '', user3: '', user4: '', user5: '' }
+                }),
+                createRawAppointment({
+                    appointmentId: 'APP2',
+                    primaryFlag: 'Y',
+                    startDate: '20241125',
+                    endDate: '20270831',
+                    jobTitle: 'ASTLE',
+                    hierarchy: { structureCode: '2', company: '1', managementUnit: 'SH', department: 'SH06', costCentre: 'DL29', division: '1', location: '77', workGroup: 'SC02', user1: '', user2: '', user3: '', user4: '', user5: '' }
+                })
+            ]
+
+            const result = AppointmentProcessorService.processAppointments(rawAppointments)
+
+            // Should merge into single appointment with primaryFlag true
+            expect(result.length).toBe(1)
+            expect(result[0].primaryFlag).toBe(true)
+        })
+
+        it('should preserve primaryFlag when merging appointments where earlier appointment is primary', () => {
+            // First appointment is primary, second is not
+            const rawAppointments = [
+                createRawAppointment({
+                    appointmentId: 'APP1',
+                    primaryFlag: 'Y',
+                    startDate: '20231121',
+                    endDate: '20241124',
+                    jobTitle: 'ASTLE',
+                    hierarchy: { structureCode: '2', company: '1', managementUnit: 'SH', department: 'SH06', costCentre: 'DL29', division: '1', location: '77', workGroup: 'SC02', user1: '', user2: '', user3: '', user4: '', user5: '' }
+                }),
+                createRawAppointment({
+                    appointmentId: 'APP2',
+                    primaryFlag: 'N',
+                    startDate: '20241125',
+                    endDate: '20270831',
+                    jobTitle: 'ASTLE',
+                    hierarchy: { structureCode: '2', company: '1', managementUnit: 'SH', department: 'SH06', costCentre: 'DL29', division: '1', location: '77', workGroup: 'SC02', user1: '', user2: '', user3: '', user4: '', user5: '' }
+                })
+            ]
+
+            const result = AppointmentProcessorService.processAppointments(rawAppointments)
+
+            // Should merge into single appointment with primaryFlag true
+            expect(result.length).toBe(1)
+            expect(result[0].primaryFlag).toBe(true)
+        })
     })
 })


### PR DESCRIPTION
Fixes bug where primaryFlag was lost when merging contiguous appointments.

When two appointments with the same job title and department are merged:
The first appointment (sorted by startDate) became the base
 - The merge only updated endDate, losing the primaryFlag from the second appointment

Now the merged appointment will have primaryFlag=true if either appointment had primaryFlag='Y'.
Added tests to cover both scenarios.