### PR TITLE
Release 0.0.12-beta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           - name: Build Package
             run: npm run build
           - name: Publish
-            run: npm publish --tag next --tag next --provenance --access public
+            run: npm publish --tag next --provenance --access public
 
   dry-run-publish:
       needs: build

--- a/dummy_proj/main.js
+++ b/dummy_proj/main.js
@@ -5,7 +5,8 @@ console.log(process.env.PEOPLEXD_URL)
 try {
     const defaultOptions = {
         titleCodeSubstitutions: {
-            CSUL: 'ALP'
+            CSUL: 'ALP',
+            GL: 'AL'
         }
     }
     const client = await PeopleXdClient.new(
@@ -17,7 +18,7 @@ try {
 
     console.log(client.getOptions())
 
-    const staffIDFail = '058279'; // Example staff ID that might not exist
+    const staffIDFail = '602786'; // Example staff ID that might not exist
     const appointments = await client.cleanAppointments(staffIDFail)
 
     console.log(appointments)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "peoplexd-client",
-  "version": "0.0.11-beta",
+  "version": "0.0.12-beta",
   "description": "A TypeScript application to interact with the PeopleXd API",
   "main": "./dist/index.cjs",
   "type": "module",

--- a/src/AppointmentProcessorService.ts
+++ b/src/AppointmentProcessorService.ts
@@ -9,7 +9,10 @@ export class AppointmentProcessorService {
      * @param rawAppointments - The raw appointment data.
      * @returns The processed appointment data.
      */
-    public static processAppointments(rawAppointments: RawAppointment[]): ProcessedAppointment[] {
+    public static processAppointments(
+        rawAppointments: RawAppointment[],
+        titleCodeSubstitutions: Record<string, string> = {}
+    ): ProcessedAppointment[] {
         if (!rawAppointments || rawAppointments.length === 0) {
             return []
         }
@@ -20,11 +23,11 @@ export class AppointmentProcessorService {
         )
 
         const mergedAppointments: ProcessedAppointment[] = []
-        const currentAppointment = this.createProcessedAppointment(sortedAppointments[0])
+        const currentAppointment = this.createProcessedAppointment(sortedAppointments[0], titleCodeSubstitutions)
 
         log(LogType.LOG, 'Processing appointments...')
 
-        this.mergeAppointments(sortedAppointments, mergedAppointments, currentAppointment)
+        this.mergeAppointments(sortedAppointments, mergedAppointments, currentAppointment, titleCodeSubstitutions)
 
         return mergedAppointments
     }
@@ -32,7 +35,8 @@ export class AppointmentProcessorService {
     private static mergeAppointments(
         rawAppointments: RawAppointment[],
         mergedAppointments: ProcessedAppointment[],
-        currentAppointment: ProcessedAppointment
+        currentAppointment: ProcessedAppointment,
+        titleCodeSubstitutions: Record<string, string> = {}
     ): void {
         for (let i = 1; i < rawAppointments.length; i++) {
             const nextAppointment = rawAppointments[i]
@@ -47,12 +51,12 @@ export class AppointmentProcessorService {
 
             log(LogType.LOG, `Days difference: ${daysDifference}`)
 
-            if (this.shouldMergeAppointments(currentAppointment, nextAppointment, daysDifference)) {
+            if (this.shouldMergeAppointments(currentAppointment, nextAppointment, daysDifference, titleCodeSubstitutions)) {
                 log(LogType.LOG, 'Merging appointments...')
                 currentAppointment = this.mergeTwoAppointments(currentAppointment, nextAppointment)
             } else {
                 mergedAppointments.push(currentAppointment)
-                currentAppointment = this.createProcessedAppointment(nextAppointment)
+                currentAppointment = this.createProcessedAppointment(nextAppointment, titleCodeSubstitutions)
             }
         }
 
@@ -75,21 +79,27 @@ export class AppointmentProcessorService {
     private static shouldMergeAppointments(
         currentAppointment: ProcessedAppointment,
         nextAppointment: RawAppointment,
-        daysDifference: number
+        daysDifference: number,
+        titleCodeSubstitutions: Record<string, string> = {}
     ): boolean {
+        const nextJobTitle = titleCodeSubstitutions[nextAppointment.jobTitle] ?? nextAppointment.jobTitle
         return (
-            currentAppointment.jobTitle === nextAppointment.jobTitle &&
+            currentAppointment.jobTitle === nextJobTitle &&
             currentAppointment.department === nextAppointment.hierarchy.department &&
             (daysDifference <= 90 || daysDifference < 0)
         ) // Merge if within 90 days or overlapping
     }
 
-    private static createProcessedAppointment(rawAppointment: RawAppointment): ProcessedAppointment {
+    private static createProcessedAppointment(
+        rawAppointment: RawAppointment,
+        titleCodeSubstitutions: Record<string, string> = {}
+    ): ProcessedAppointment {
+        const normalisedJobTitle = titleCodeSubstitutions[rawAppointment.jobTitle] ?? rawAppointment.jobTitle
         return {
             appointmentId: rawAppointment.appointmentId,
             primaryFlag: rawAppointment.primaryFlag === 'Y',
-            jobTitle: rawAppointment.jobTitle,
-            fullJobTitle: rawAppointment.jobTitle,
+            jobTitle: normalisedJobTitle,
+            fullJobTitle: normalisedJobTitle,
             department: rawAppointment.hierarchy.department,
             fullDepartment: rawAppointment.hierarchy.department,
             startDate: rawAppointment.startDate,

--- a/src/AppointmentService.ts
+++ b/src/AppointmentService.ts
@@ -20,7 +20,8 @@ export class AppointmentService {
         const departmentCache = new Map<string, string>()
         const jobTitleCache = new Map<string, string>()
 
-        const cleanedAppointments = AppointmentProcessorService.processAppointments(rawAppointments)
+        const titleCodeSubstitutions = this.client.getOptions().titleCodeSubstitutions ?? {}
+        const cleanedAppointments = AppointmentProcessorService.processAppointments(rawAppointments, titleCodeSubstitutions)
 
         for (const cleanedAppointment of cleanedAppointments) {
             const fullDepartment = departmentCache.get(cleanedAppointment.department)

--- a/tests/AppointmentProcessorService.test.ts
+++ b/tests/AppointmentProcessorService.test.ts
@@ -112,5 +112,57 @@ describe('AppointmentProcessorService', () => {
             expect(result.length).toBe(1)
             expect(result[0].primaryFlag).toBe(true)
         })
+
+        it('should merge contiguous appointments when titleCodeSubstitutions maps different codes to the same value', () => {
+            const rawAppointments = [
+                createRawAppointment({
+                    appointmentId: 'APP1',
+                    startDate: '20230101',
+                    endDate: '20230630',
+                    jobTitle: 'GL',
+                    hierarchy: { structureCode: '2', company: '1', managementUnit: 'SH', department: 'SH06', costCentre: 'DL29', division: '1', location: '77', workGroup: 'SC02', user1: '', user2: '', user3: '', user4: '', user5: '' }
+                }),
+                createRawAppointment({
+                    appointmentId: 'APP2',
+                    startDate: '20230701',
+                    endDate: '20231231',
+                    jobTitle: 'AL',
+                    hierarchy: { structureCode: '2', company: '1', managementUnit: 'SH', department: 'SH06', costCentre: 'DL29', division: '1', location: '77', workGroup: 'SC02', user1: '', user2: '', user3: '', user4: '', user5: '' }
+                })
+            ]
+
+            const substitutions = { GL: 'AL' }
+            const result = AppointmentProcessorService.processAppointments(rawAppointments, substitutions)
+
+            expect(result.length).toBe(1)
+            expect(result[0].jobTitle).toBe('AL')
+            expect(result[0].startDate).toBe('20230101')
+            expect(result[0].endDate).toBe('20231231')
+        })
+
+        it('should not merge contiguous appointments with different codes when no substitutions are provided', () => {
+            const rawAppointments = [
+                createRawAppointment({
+                    appointmentId: 'APP1',
+                    startDate: '20230101',
+                    endDate: '20230630',
+                    jobTitle: 'GL',
+                    hierarchy: { structureCode: '2', company: '1', managementUnit: 'SH', department: 'SH06', costCentre: 'DL29', division: '1', location: '77', workGroup: 'SC02', user1: '', user2: '', user3: '', user4: '', user5: '' }
+                }),
+                createRawAppointment({
+                    appointmentId: 'APP2',
+                    startDate: '20230701',
+                    endDate: '20231231',
+                    jobTitle: 'AL',
+                    hierarchy: { structureCode: '2', company: '1', managementUnit: 'SH', department: 'SH06', costCentre: 'DL29', division: '1', location: '77', workGroup: 'SC02', user1: '', user2: '', user3: '', user4: '', user5: '' }
+                })
+            ]
+
+            const result = AppointmentProcessorService.processAppointments(rawAppointments)
+
+            expect(result.length).toBe(2)
+            expect(result[0].jobTitle).toBe('GL')
+            expect(result[1].jobTitle).toBe('AL')
+        })
     })
 })

--- a/tests/AppointmentService.test.ts
+++ b/tests/AppointmentService.test.ts
@@ -23,7 +23,8 @@ describe('AppointmentService', () => {
         client = {
             request: jest.fn(),
             getFullDepartment: jest.fn(),
-            getFullJobTitle: jest.fn()
+            getFullJobTitle: jest.fn(),
+            getOptions: jest.fn().mockReturnValue({})
         } as unknown as jest.Mocked<PeopleXdClient>
 
         // Create an instance of AppointmentService with the mock client
@@ -138,7 +139,7 @@ describe('AppointmentService', () => {
 
             // Verify method calls
             expect(appointmentService.getAppointments).toHaveBeenCalledWith(staffNumber)
-            expect(AppointmentProcessorService.processAppointments).toHaveBeenCalledWith(rawAppointments)
+            expect(AppointmentProcessorService.processAppointments).toHaveBeenCalledWith(rawAppointments, {})
             expect(client.getFullDepartment).toHaveBeenCalledWith('IT')
             expect(client.getFullJobTitle).toHaveBeenCalledWith('DEV')
 
@@ -199,7 +200,7 @@ describe('AppointmentService', () => {
 
             // Verify method calls
             expect(appointmentService.getAppointments).toHaveBeenCalledWith(staffNumber)
-            expect(AppointmentProcessorService.processAppointments).toHaveBeenCalledWith(rawAppointments)
+            expect(AppointmentProcessorService.processAppointments).toHaveBeenCalledWith(rawAppointments, {})
 
             // Verify result
             expect(result.length).toBe(2)


### PR DESCRIPTION
## Release 0.0.12-beta

Merges staging into main to trigger npm publish.

### Changes
- **fix:** Apply `titleCodeSubstitutions` to appointment merging — contiguous appointments with equivalent codes now merge correctly, and the `jobTitle` field is normalised
- **ci:** Fix duplicate `--tag next` in publish step
- Version bumped to `0.0.12-beta`