### PR TITLE
release: publish 0.0.13-beta (staging→main)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "peoplexd-client",
-  "version": "0.0.10-beta",
+  "version": "0.0.13-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "peoplexd-client",
-      "version": "0.0.10-beta",
+      "version": "0.0.13-beta",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "peoplexd-client",
-  "version": "0.0.12-beta",
+  "version": "0.0.13-beta",
   "description": "A TypeScript application to interact with the PeopleXd API",
   "main": "./dist/index.cjs",
   "type": "module",

--- a/src/AppointmentInterfaces.ts
+++ b/src/AppointmentInterfaces.ts
@@ -46,4 +46,11 @@ export interface ProcessedAppointment {
     fullDepartment: string
     startDate: string
     endDate: string
+    /**
+     * Present and `true` only when `cleanAppointments` is run with
+     * `tolerateMissingReferenceData: true` and the DEPT reference lookup
+     * returned no record for `department`. `fullDepartment` will then equal
+     * `department` (the raw code).
+     */
+    fullDepartmentMissing?: boolean
 }

--- a/src/AppointmentService.ts
+++ b/src/AppointmentService.ts
@@ -17,33 +17,56 @@ export class AppointmentService {
     public async cleanAppointments(staffNumber: string): Promise<ProcessedAppointment[]> {
         const rawAppointments = await this.getAppointments(staffNumber)
         const processedAppointments: ProcessedAppointment[] = []
-        const departmentCache = new Map<string, string>()
+        const departmentCache = new Map<string, { fullDepartment: string; missing: boolean }>()
         const jobTitleCache = new Map<string, string>()
 
-        const titleCodeSubstitutions = this.client.getOptions().titleCodeSubstitutions ?? {}
+        const options = this.client.getOptions()
+        const tolerateMissing = options.tolerateMissingReferenceData === true
+        const titleCodeSubstitutions = options.titleCodeSubstitutions ?? {}
         const cleanedAppointments = AppointmentProcessorService.processAppointments(rawAppointments, titleCodeSubstitutions)
 
         for (const cleanedAppointment of cleanedAppointments) {
-            const fullDepartment = departmentCache.get(cleanedAppointment.department)
-                ?? (await this.client.getFullDepartment(cleanedAppointment.department))
-            departmentCache.set(cleanedAppointment.department, fullDepartment)
+            let deptEntry = departmentCache.get(cleanedAppointment.department)
+            if (!deptEntry) {
+                deptEntry = await this.resolveDepartment(cleanedAppointment.department, tolerateMissing)
+                departmentCache.set(cleanedAppointment.department, deptEntry)
+            }
 
             const fullJobTitle = jobTitleCache.get(cleanedAppointment.jobTitle)
                 ?? (await this.client.getFullJobTitle(cleanedAppointment.jobTitle))
             jobTitleCache.set(cleanedAppointment.jobTitle, fullJobTitle)
 
-            processedAppointments.push({
+            const appointment: ProcessedAppointment = {
                 appointmentId: cleanedAppointment.appointmentId,
                 primaryFlag: cleanedAppointment.primaryFlag,
                 jobTitle: cleanedAppointment.jobTitle,
                 fullJobTitle: fullJobTitle,
                 department: cleanedAppointment.department,
-                fullDepartment: fullDepartment,
+                fullDepartment: deptEntry.fullDepartment,
                 startDate: cleanedAppointment.startDate,
                 endDate: cleanedAppointment.endDate
-            })
+            }
+            if (deptEntry.missing) {
+                appointment.fullDepartmentMissing = true
+            }
+            processedAppointments.push(appointment)
         }
 
         return processedAppointments
+    }
+
+    private async resolveDepartment(
+        deptCode: string,
+        tolerateMissing: boolean
+    ): Promise<{ fullDepartment: string; missing: boolean }> {
+        if (!tolerateMissing) {
+            return { fullDepartment: await this.client.getFullDepartment(deptCode), missing: false }
+        }
+
+        const reference = await this.client.getDepartmentReference(deptCode)
+        if (reference) {
+            return { fullDepartment: reference.description, missing: false }
+        }
+        return { fullDepartment: deptCode, missing: true }
     }
 }

--- a/src/DepartmentService.ts
+++ b/src/DepartmentService.ts
@@ -1,6 +1,19 @@
-import { AxiosResponse } from 'axios'
+import axios, { AxiosResponse } from 'axios'
 import { PeopleXdClient } from './PeopleXdClient'
 import { decodeHtml } from './Utilities'
+
+export interface DepartmentReference {
+    code: string
+    description: string
+    active: 'Y' | 'N'
+}
+
+export interface ListDepartmentsOptions {
+    activeOnly?: boolean
+    pageSize?: number
+}
+
+const DEFAULT_PAGE_SIZE = 100
 
 export class DepartmentService {
     private client: PeopleXdClient
@@ -13,6 +26,36 @@ export class DepartmentService {
         return await this.client.request('GET', `v1/reference/type/DEPT/${decodeHtml(deptCode)}`)
     }
 
+    /**
+     * Fetch a single DEPT reference record. Returns `null` when the code is unknown
+     * (HTTP 404 or empty `items`). Re-throws all other errors so transport/auth
+     * failures are not silently masked.
+     */
+    public async getDepartmentReference(deptCode: string): Promise<DepartmentReference | null> {
+        let response: AxiosResponse
+        try {
+            response = await this.getDepartment(deptCode)
+        } catch (error: unknown) {
+            if (axios.isAxiosError(error) && error.response?.status === 404) {
+                return null
+            }
+            throw error
+        }
+
+        const item = response?.data?.items?.[0] as
+            | { code?: string; description?: string; active?: string }
+            | undefined
+        if (!item?.description) {
+            return null
+        }
+
+        return {
+            code: item.code ?? deptCode,
+            description: decodeHtml(item.description),
+            active: item.active === 'Y' ? 'Y' : 'N'
+        }
+    }
+
     public async getFullDepartment(deptCode: string): Promise<string> {
         const response = await this.getDepartment(deptCode)
         const description = response?.data?.items?.[0]?.description
@@ -22,5 +65,50 @@ export class DepartmentService {
         }
 
         return decodeHtml(description)
+    }
+
+    /**
+     * Stream every DEPT reference record using the paged `v1/reference/type/DEPT`
+     * endpoint. Defaults match the raw API: all records (including inactive),
+     * page size 100.
+     */
+    public async *listDepartments(
+        options: ListDepartmentsOptions = {}
+    ): AsyncIterable<DepartmentReference> {
+        const pageSize = options.pageSize ?? DEFAULT_PAGE_SIZE
+        const activeOnly = options.activeOnly ?? false
+        let offset = 0
+
+        while (true) {
+            const response = await this.client.request(
+                'GET',
+                `v1/reference/type/DEPT?limit=${pageSize}&offsetby=${offset}`
+            )
+            const items = (response?.data?.items ?? []) as Array<{
+                code?: string
+                description?: string
+                active?: string
+            }>
+
+            for (const item of items) {
+                if (!item.code || !item.description) {
+                    continue
+                }
+                if (activeOnly && item.active !== 'Y') {
+                    continue
+                }
+                yield {
+                    code: item.code,
+                    description: decodeHtml(item.description),
+                    active: item.active === 'Y' ? 'Y' : 'N'
+                }
+            }
+
+            const hasMore = Boolean(response?.data?.hasMore)
+            if (!hasMore || items.length === 0) {
+                return
+            }
+            offset += items.length
+        }
     }
 }

--- a/src/PeopleXdClient.ts
+++ b/src/PeopleXdClient.ts
@@ -3,7 +3,11 @@ import { TokenManagerService } from './TokenManagerService'
 import { ProcessedAppointment } from './AppointmentInterfaces'
 import { HttpClient } from './HttpClient'
 import { AppointmentService } from './AppointmentService'
-import { DepartmentService } from './DepartmentService'
+import {
+    DepartmentService,
+    DepartmentReference,
+    ListDepartmentsOptions
+} from './DepartmentService'
 import { PositionService } from './PositionService'
 
 export enum HttpRequestMethod {
@@ -22,6 +26,15 @@ export interface PeopleXdClientOptions {
      * Example: { 'HPAL': 'AL' } would replace "Hourly Paid Assistant Lecturer" with "Assistant Lecturer"
      */
     titleCodeSubstitutions?: Record<string, string>
+
+    /**
+     * When true, `cleanAppointments` will not throw if an appointment references a
+     * department whose DEPT reference record is missing (HTTP 404 or empty `items`).
+     * Instead, `fullDepartment` falls back to the raw code and `fullDepartmentMissing`
+     * is set to true on the returned `ProcessedAppointment`. Transport errors are
+     * still propagated.
+     */
+    tolerateMissingReferenceData?: boolean
 }
 
 /**
@@ -70,6 +83,23 @@ export class PeopleXdClient {
 
     public async getFullDepartment(deptCode: string): Promise<string> {
         return await this.departmentService.getFullDepartment(deptCode)
+    }
+
+    /**
+     * Fetch a single DEPT reference record. Returns `null` for unknown codes
+     * (HTTP 404 or empty `items`); other errors propagate.
+     */
+    public async getDepartmentReference(deptCode: string): Promise<DepartmentReference | null> {
+        return await this.departmentService.getDepartmentReference(deptCode)
+    }
+
+    /**
+     * Async-iterate every DEPT reference record (paged).
+     */
+    public listDepartments(
+        options: ListDepartmentsOptions = {}
+    ): AsyncIterable<DepartmentReference> {
+        return this.departmentService.listDepartments(options)
     }
 
     public async getFullJobTitle(positionCode: string): Promise<string> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,11 @@
-import { PeopleXdClient } from './PeopleXdClient'
+import { PeopleXdClient, PeopleXdClientOptions } from './PeopleXdClient'
+import { DepartmentReference, ListDepartmentsOptions } from './DepartmentService'
+import { ProcessedAppointment } from './AppointmentInterfaces'
 
 export { PeopleXdClient }
+export type {
+    PeopleXdClientOptions,
+    DepartmentReference,
+    ListDepartmentsOptions,
+    ProcessedAppointment
+}

--- a/tests/AppointmentService.test.ts
+++ b/tests/AppointmentService.test.ts
@@ -23,6 +23,7 @@ describe('AppointmentService', () => {
         client = {
             request: jest.fn(),
             getFullDepartment: jest.fn(),
+            getDepartmentReference: jest.fn(),
             getFullJobTitle: jest.fn(),
             getOptions: jest.fn().mockReturnValue({})
         } as unknown as jest.Mocked<PeopleXdClient>
@@ -223,6 +224,95 @@ describe('AppointmentService', () => {
             expect(result.length).toBe(0)
             expect(client.getFullDepartment).not.toHaveBeenCalled()
             expect(client.getFullJobTitle).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('cleanAppointments tolerateMissingReferenceData', () => {
+        beforeEach(() => {
+            ;(client.getOptions as jest.Mock).mockReturnValue({ tolerateMissingReferenceData: true })
+        })
+
+        it('falls back to the raw code and flags fullDepartmentMissing when reference is null', async () => {
+            const rawAppointments: RawAppointment[] = [
+                createRawAppointment({
+                    appointmentId: 'APP1',
+                    jobTitle: 'DEV',
+                    hierarchy: createHierarchy({ department: 'DCRO' })
+                })
+            ]
+            const processedAppointments: ProcessedAppointment[] = [
+                createProcessedAppointment({
+                    appointmentId: 'APP1',
+                    jobTitle: 'DEV',
+                    department: 'DCRO'
+                })
+            ]
+
+            jest.spyOn(appointmentService, 'getAppointments').mockResolvedValue(rawAppointments)
+            ;(AppointmentProcessorService.processAppointments as jest.Mock).mockReturnValue(processedAppointments)
+            ;(client.getDepartmentReference as jest.Mock).mockResolvedValue(null)
+            client.getFullJobTitle.mockResolvedValue('Software Developer')
+
+            const result = await appointmentService.cleanAppointments(staffNumber)
+
+            expect(client.getDepartmentReference).toHaveBeenCalledWith('DCRO')
+            expect(client.getFullDepartment).not.toHaveBeenCalled()
+            expect(result[0].fullDepartment).toBe('DCRO')
+            expect(result[0].fullDepartmentMissing).toBe(true)
+        })
+
+        it('uses the reference description when present and does not set the missing flag', async () => {
+            const rawAppointments: RawAppointment[] = [
+                createRawAppointment({
+                    appointmentId: 'APP1',
+                    jobTitle: 'DEV',
+                    hierarchy: createHierarchy({ department: 'IT' })
+                })
+            ]
+            const processedAppointments: ProcessedAppointment[] = [
+                createProcessedAppointment({
+                    appointmentId: 'APP1',
+                    jobTitle: 'DEV',
+                    department: 'IT'
+                })
+            ]
+
+            jest.spyOn(appointmentService, 'getAppointments').mockResolvedValue(rawAppointments)
+            ;(AppointmentProcessorService.processAppointments as jest.Mock).mockReturnValue(processedAppointments)
+            ;(client.getDepartmentReference as jest.Mock).mockResolvedValue({
+                code: 'IT',
+                description: 'Information Technology Department',
+                active: 'Y'
+            })
+            client.getFullJobTitle.mockResolvedValue('Software Developer')
+
+            const result = await appointmentService.cleanAppointments(staffNumber)
+
+            expect(result[0].fullDepartment).toBe('Information Technology Department')
+            expect(result[0].fullDepartmentMissing).toBeUndefined()
+        })
+
+        it('still propagates non-404 errors from the reference lookup', async () => {
+            const rawAppointments: RawAppointment[] = [
+                createRawAppointment({
+                    appointmentId: 'APP1',
+                    jobTitle: 'DEV',
+                    hierarchy: createHierarchy({ department: 'IT' })
+                })
+            ]
+            const processedAppointments: ProcessedAppointment[] = [
+                createProcessedAppointment({
+                    appointmentId: 'APP1',
+                    jobTitle: 'DEV',
+                    department: 'IT'
+                })
+            ]
+
+            jest.spyOn(appointmentService, 'getAppointments').mockResolvedValue(rawAppointments)
+            ;(AppointmentProcessorService.processAppointments as jest.Mock).mockReturnValue(processedAppointments)
+            ;(client.getDepartmentReference as jest.Mock).mockRejectedValue(new Error('boom'))
+
+            await expect(appointmentService.cleanAppointments(staffNumber)).rejects.toThrow('boom')
         })
     })
 })

--- a/tests/DepartmentService.test.ts
+++ b/tests/DepartmentService.test.ts
@@ -1,4 +1,4 @@
-import { AxiosResponse, AxiosHeaders } from 'axios'
+import { AxiosResponse, AxiosHeaders, AxiosError } from 'axios'
 import { DepartmentService } from '../src/DepartmentService'
 import { PeopleXdClient } from '../src/PeopleXdClient'
 
@@ -136,6 +136,184 @@ describe('DepartmentService', () => {
 
             // Verify request was called
             expect(client.request).toHaveBeenCalledWith('GET', `v1/reference/type/DEPT/${deptCode}`)
+        })
+    })
+
+    describe('getDepartmentReference method', () => {
+        const deptCode = 'DCRO'
+
+        const buildResponse = (data: unknown): AxiosResponse => ({
+            data,
+            status: 200,
+            statusText: 'OK',
+            headers: {},
+            config: { headers: new AxiosHeaders() }
+        })
+
+        it('returns a decoded reference record', async () => {
+            ;(client.request as jest.Mock).mockResolvedValue(
+                buildResponse({
+                    items: [
+                        {
+                            type: 'DEPT',
+                            code: 'DCRO',
+                            description: 'Office of the CRO &amp; Co',
+                            active: 'Y'
+                        }
+                    ]
+                })
+            )
+
+            const result = await departmentService.getDepartmentReference(deptCode)
+
+            expect(client.request).toHaveBeenCalledWith('GET', `v1/reference/type/DEPT/${deptCode}`)
+            expect(result).toEqual({
+                code: 'DCRO',
+                description: 'Office of the CRO & Co',
+                active: 'Y'
+            })
+        })
+
+        it('returns null when items is empty', async () => {
+            ;(client.request as jest.Mock).mockResolvedValue(buildResponse({ items: [] }))
+            const result = await departmentService.getDepartmentReference(deptCode)
+            expect(result).toBeNull()
+        })
+
+        it('returns null on HTTP 404', async () => {
+            const error = new AxiosError('not found')
+            error.response = {
+                status: 404,
+                statusText: 'Not Found',
+                data: {},
+                headers: {},
+                config: { headers: new AxiosHeaders() }
+            }
+            ;(client.request as jest.Mock).mockRejectedValue(error)
+
+            const result = await departmentService.getDepartmentReference(deptCode)
+            expect(result).toBeNull()
+        })
+
+        it('rethrows non-404 axios errors', async () => {
+            const error = new AxiosError('server boom')
+            error.response = {
+                status: 500,
+                statusText: 'Server Error',
+                data: {},
+                headers: {},
+                config: { headers: new AxiosHeaders() }
+            }
+            ;(client.request as jest.Mock).mockRejectedValue(error)
+
+            await expect(departmentService.getDepartmentReference(deptCode)).rejects.toThrow('server boom')
+        })
+
+        it('rethrows non-axios errors', async () => {
+            ;(client.request as jest.Mock).mockRejectedValue(new Error('network down'))
+            await expect(departmentService.getDepartmentReference(deptCode)).rejects.toThrow('network down')
+        })
+
+        it("defaults active to 'N' when the API omits or denies it", async () => {
+            ;(client.request as jest.Mock).mockResolvedValue(
+                buildResponse({
+                    items: [{ code: 'OLD', description: 'Retired', active: 'N' }]
+                })
+            )
+
+            const result = await departmentService.getDepartmentReference('OLD')
+            expect(result?.active).toBe('N')
+        })
+    })
+
+    describe('listDepartments method', () => {
+        const buildPage = (
+            items: Array<{ code: string; description: string; active: 'Y' | 'N' }>,
+            hasMore: boolean
+        ): AxiosResponse => ({
+            data: { items, limit: items.length, offsetby: 0, count: items.length, hasMore },
+            status: 200,
+            statusText: 'OK',
+            headers: {},
+            config: { headers: new AxiosHeaders() }
+        })
+
+        it('streams paged results until hasMore is false', async () => {
+            ;(client.request as jest.Mock)
+                .mockResolvedValueOnce(
+                    buildPage(
+                        [
+                            { code: 'A', description: 'Alpha', active: 'Y' },
+                            { code: 'B', description: 'Beta &amp;', active: 'N' }
+                        ],
+                        true
+                    )
+                )
+                .mockResolvedValueOnce(
+                    buildPage([{ code: 'C', description: 'Gamma', active: 'Y' }], false)
+                )
+
+            const collected: Array<{ code: string; description: string; active: 'Y' | 'N' }> = []
+            for await (const item of departmentService.listDepartments()) {
+                collected.push(item)
+            }
+
+            expect(client.request).toHaveBeenNthCalledWith(
+                1,
+                'GET',
+                'v1/reference/type/DEPT?limit=100&offsetby=0'
+            )
+            expect(client.request).toHaveBeenNthCalledWith(
+                2,
+                'GET',
+                'v1/reference/type/DEPT?limit=100&offsetby=2'
+            )
+            expect(collected).toEqual([
+                { code: 'A', description: 'Alpha', active: 'Y' },
+                { code: 'B', description: 'Beta &', active: 'N' },
+                { code: 'C', description: 'Gamma', active: 'Y' }
+            ])
+        })
+
+        it('filters inactive records when activeOnly is true', async () => {
+            ;(client.request as jest.Mock).mockResolvedValue(
+                buildPage(
+                    [
+                        { code: 'A', description: 'Alpha', active: 'Y' },
+                        { code: 'B', description: 'Beta', active: 'N' }
+                    ],
+                    false
+                )
+            )
+
+            const collected = []
+            for await (const item of departmentService.listDepartments({ activeOnly: true })) {
+                collected.push(item)
+            }
+
+            expect(collected).toEqual([{ code: 'A', description: 'Alpha', active: 'Y' }])
+        })
+
+        it('respects a custom pageSize', async () => {
+            ;(client.request as jest.Mock).mockResolvedValue(buildPage([], false))
+
+            const iter = departmentService.listDepartments({ pageSize: 25 })
+            await iter[Symbol.asyncIterator]().next()
+
+            expect(client.request).toHaveBeenCalledWith(
+                'GET',
+                'v1/reference/type/DEPT?limit=25&offsetby=0'
+            )
+        })
+
+        it('stops on an empty page even if hasMore is true', async () => {
+            ;(client.request as jest.Mock).mockResolvedValue(buildPage([], true))
+            const collected = []
+            for await (const item of departmentService.listDepartments()) {
+                collected.push(item)
+            }
+            expect(collected).toEqual([])
+            expect(client.request).toHaveBeenCalledTimes(1)
         })
     })
 })

--- a/tests/PeopleXdClient.test.ts
+++ b/tests/PeopleXdClient.test.ts
@@ -116,6 +116,42 @@ describe('PeopleXdClient', () => {
         })
     })
 
+    describe('getDepartmentReference method', () => {
+        it('should delegate to departmentService.getDepartmentReference', async () => {
+            const deptCode = 'DCRO'
+            const reference = { code: 'DCRO', description: 'Office of the CRO', active: 'Y' as const }
+            const departmentServiceMock = (client as unknown as { departmentService: jest.Mocked<DepartmentService> })
+                .departmentService
+            departmentServiceMock.getDepartmentReference.mockResolvedValue(reference)
+
+            const result = await client.getDepartmentReference(deptCode)
+
+            expect(departmentServiceMock.getDepartmentReference).toHaveBeenCalledWith(deptCode)
+            expect(result).toBe(reference)
+        })
+    })
+
+    describe('listDepartments method', () => {
+        it('should delegate to departmentService.listDepartments and pass options through', async () => {
+            const departmentServiceMock = (client as unknown as { departmentService: jest.Mocked<DepartmentService> })
+                .departmentService
+
+            async function* fakeIterator() {
+                yield { code: 'A', description: 'Alpha', active: 'Y' as const }
+                yield { code: 'B', description: 'Beta', active: 'N' as const }
+            }
+            departmentServiceMock.listDepartments.mockReturnValue(fakeIterator())
+
+            const collected = []
+            for await (const item of client.listDepartments({ activeOnly: true, pageSize: 50 })) {
+                collected.push(item)
+            }
+
+            expect(departmentServiceMock.listDepartments).toHaveBeenCalledWith({ activeOnly: true, pageSize: 50 })
+            expect(collected).toHaveLength(2)
+        })
+    })
+
     describe('getFullJobTitle method', () => {
         it('should delegate to positionService.getFullJobTitle with original code when no substitution exists', async () => {
             const positionCode = 'P001'


### PR DESCRIPTION
Promote staging to main to publish `peoplexd-client@0.0.13-beta`.

Rolls up:
- #28 — feat: expose department reference lookups and tolerate missing data (Closes #27)

This release adds `getDepartmentReference`, `listDepartments` and the opt-in `tolerateMissingReferenceData` option needed by tu-dublin-csu/pure-dash-nest#182.
